### PR TITLE
Ensure Java 8 compatibility for monitor services

### DIFF
--- a/src/main/java/com/example/monitor/DexConstants.java
+++ b/src/main/java/com/example/monitor/DexConstants.java
@@ -1,5 +1,7 @@
 package com.example.monitor;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,22 +28,22 @@ public class DexConstants {
     public static final String BUSD_ADDRESS = "0xe9e7cea3dedca5984780bafc599bd69add087d56";
 
     /** PancakeSwap V2 工厂列表 */
-    public static final List<String> V2_FACTORIES = List.of(
+    public static final List<String> V2_FACTORIES = Collections.unmodifiableList(Arrays.asList(
             PANCAKE_V2_FACTORY,
             UNISWAP_V2_FACTORY
-    );
+    ));
 
     /** PancakeSwap V3 工厂列表 */
-    public static final List<String> V3_FACTORIES = List.of(
+    public static final List<String> V3_FACTORIES = Collections.unmodifiableList(Arrays.asList(
             PANCAKE_V3_FACTORY,
             UNISWAP_V3_FACTORY
-    );
+    ));
 
     /** PancakeSwap V4 工厂列表 */
-    public static final List<String> V4_FACTORIES = List.of(
+    public static final List<String> V4_FACTORIES = Collections.unmodifiableList(Arrays.asList(
             PANCAKE_V4_FACTORY,
             UNISWAP_V4_FACTORY
-    );
+    ));
 
     private DexConstants() {
     }

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -131,18 +131,18 @@ public class DexPriceService {
      */
     private Optional<BigDecimal> calculatePriceFromPair(PairMetadata pairMetadata, BigInteger blockNumber) {
         Optional<Reserves> reservesOpt = getReserves(pairMetadata, blockNumber);
-        if (reservesOpt.isEmpty()) {
+        if (!reservesOpt.isPresent()) {
             return Optional.empty();
         }
         Reserves reserves = reservesOpt.get();
         BigDecimal tokenReserve;
         BigDecimal quoteReserve;
         if (pairMetadata.token0.equalsIgnoreCase(tokenAddress)) {
-            tokenReserve = reserves.reserve0.divide(BigDecimal.TEN.pow(tokenDecimals.intValue()), 18, RoundingMode.HALF_UP);
-            quoteReserve = reserves.reserve1.divide(BigDecimal.TEN.pow(pairMetadata.token1Decimals.intValue()), 18, RoundingMode.HALF_UP);
+            tokenReserve = reserves.getReserve0().divide(BigDecimal.TEN.pow(tokenDecimals.intValue()), 18, RoundingMode.HALF_UP);
+            quoteReserve = reserves.getReserve1().divide(BigDecimal.TEN.pow(pairMetadata.token1Decimals.intValue()), 18, RoundingMode.HALF_UP);
         } else {
-            tokenReserve = reserves.reserve1.divide(BigDecimal.TEN.pow(tokenDecimals.intValue()), 18, RoundingMode.HALF_UP);
-            quoteReserve = reserves.reserve0.divide(BigDecimal.TEN.pow(pairMetadata.token0Decimals.intValue()), 18, RoundingMode.HALF_UP);
+            tokenReserve = reserves.getReserve1().divide(BigDecimal.TEN.pow(tokenDecimals.intValue()), 18, RoundingMode.HALF_UP);
+            quoteReserve = reserves.getReserve0().divide(BigDecimal.TEN.pow(pairMetadata.token0Decimals.intValue()), 18, RoundingMode.HALF_UP);
         }
         if (tokenReserve.compareTo(BigDecimal.ZERO) == 0) {
             return Optional.empty();
@@ -308,7 +308,22 @@ public class DexPriceService {
     /**
      * 储备数据结构
      */
-    private record Reserves(BigDecimal reserve0, BigDecimal reserve1) {
+    private static class Reserves {
+        private final BigDecimal reserve0;
+        private final BigDecimal reserve1;
+
+        private Reserves(BigDecimal reserve0, BigDecimal reserve1) {
+            this.reserve0 = reserve0;
+            this.reserve1 = reserve1;
+        }
+
+        public BigDecimal getReserve0() {
+            return reserve0;
+        }
+
+        public BigDecimal getReserve1() {
+            return reserve1;
+        }
     }
 
     /**

--- a/src/main/java/com/example/monitor/TokenInfoService.java
+++ b/src/main/java/com/example/monitor/TokenInfoService.java
@@ -50,10 +50,12 @@ public class TokenInfoService {
                 Collections.singletonList(new TypeReference<Uint8>() {
                 })
         );
-        return callSingleValueReturn(tokenAddress, function)
-                .map(value -> (Uint8) value)
-                .map(Uint8::getValue)
-                .or(() -> Optional.of(BigInteger.valueOf(18))); // 默认 18 位精度
+        Optional<Type> result = callSingleValueReturn(tokenAddress, function);
+        if (result.isPresent()) {
+            Uint8 value = (Uint8) result.get();
+            return Optional.ofNullable(value.getValue());
+        }
+        return Optional.of(BigInteger.valueOf(18)); // 默认 18 位精度
     }
 
     /**

--- a/src/main/java/com/example/monitor/TransferAggregator.java
+++ b/src/main/java/com/example/monitor/TransferAggregator.java
@@ -74,8 +74,8 @@ public class TransferAggregator {
     public synchronized BigDecimal getVolume24h() {
         long cutoff = Instant.now().minusSeconds(24 * 3600).toEpochMilli();
         return recentTransfers.stream()
-                .filter(record -> record.timestamp() >= cutoff)
-                .map(TransferRecord::usdValue)
+                .filter(record -> record.getTimestamp() >= cutoff)
+                .map(TransferRecord::getUsdValue)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
@@ -86,9 +86,9 @@ public class TransferAggregator {
      */
     public synchronized BigDecimal getNetFlow() {
         return recentTransfers.stream()
-                .map(record -> record.direction() == TransferRecord.Direction.BUY
-                        ? record.usdValue()
-                        : record.usdValue().negate())
+                .map(record -> record.getDirection() == TransferRecord.Direction.BUY
+                        ? record.getUsdValue()
+                        : record.getUsdValue().negate())
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
@@ -99,7 +99,7 @@ public class TransferAggregator {
      */
     private void cleanup(long currentTimestamp) {
         long cutoff = currentTimestamp - 24 * 3600 * 1000L;
-        while (!recentTransfers.isEmpty() && recentTransfers.peek().timestamp() < cutoff) {
+        while (!recentTransfers.isEmpty() && recentTransfers.peek().getTimestamp() < cutoff) {
             recentTransfers.poll();
         }
     }
@@ -107,7 +107,29 @@ public class TransferAggregator {
     /**
      * 转账记录结构体
      */
-    public record TransferRecord(long timestamp, BigDecimal usdValue, Direction direction) {
+    public static class TransferRecord {
+        private final long timestamp;
+        private final BigDecimal usdValue;
+        private final Direction direction;
+
+        public TransferRecord(long timestamp, BigDecimal usdValue, Direction direction) {
+            this.timestamp = timestamp;
+            this.usdValue = usdValue;
+            this.direction = direction;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+
+        public BigDecimal getUsdValue() {
+            return usdValue;
+        }
+
+        public Direction getDirection() {
+            return direction;
+        }
+
         /** 方向枚举 */
         public enum Direction {
             /** 买入 */


### PR DESCRIPTION
## Summary
- replace Java 9+ collection factory methods with Java 8 compatible alternatives
- refactor record types and Optional APIs to implementations supported on Java 8

## Testing
- `mvn -q -DskipTests compile` *(fails: Maven Central 403 while resolving maven-resources-plugin 3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c2e31fb883269efa484b10a52627