### PR TITLE
Support initializing V3 pools alongside V2

### DIFF
--- a/src/main/java/com/example/monitor/DexConstants.java
+++ b/src/main/java/com/example/monitor/DexConstants.java
@@ -1,5 +1,6 @@
 package com.example.monitor;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -37,6 +38,14 @@ public class DexConstants {
     public static final List<String> V3_FACTORIES = Collections.unmodifiableList(Arrays.asList(
             PANCAKE_V3_FACTORY,
             UNISWAP_V3_FACTORY
+    ));
+
+    /** V3 可用费率列表（以 1e-6 计） */
+    public static final List<BigInteger> V3_FEE_TIERS = Collections.unmodifiableList(Arrays.asList(
+            BigInteger.valueOf(100),      // 0.01%
+            BigInteger.valueOf(500),      // 0.05%
+            BigInteger.valueOf(2500),     // 0.25%
+            BigInteger.valueOf(10000)     // 1%
     ));
 
     /** PancakeSwap V4 工厂列表 */

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -9,6 +9,7 @@ import org.web3j.abi.datatypes.Address;
 import org.web3j.abi.datatypes.Function;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.generated.Uint112;
+import org.web3j.abi.datatypes.generated.Uint24;
 import org.web3j.abi.datatypes.generated.Uint32;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
@@ -39,8 +40,12 @@ public class DexPriceService {
     /** 代币符号 */
     private final String tokenSymbol;
 
-    /** 缓存的 V2 配对信息 */
-    private final Map<String, PairMetadata> pairCache = new ConcurrentHashMap<>();
+    /** 按 token 组合缓存的 V2 配对信息 */
+    private final Map<String, PairMetadata> pairCacheByTokens = new ConcurrentHashMap<>();
+    /** 按地址缓存的池子信息 */
+    private final Map<String, PairMetadata> pairCacheByAddress = new ConcurrentHashMap<>();
+    /** 按 token 与费率缓存的 V3 池子信息 */
+    private final Map<String, PairMetadata> v3PoolCache = new ConcurrentHashMap<>();
 
     /**
      * 构造函数
@@ -159,15 +164,40 @@ public class DexPriceService {
      */
     public Optional<PairMetadata> findOrCreatePair(String tokenA, String tokenB) {
         String key = buildPairKey(tokenA, tokenB);
-        if (pairCache.containsKey(key)) {
-            return Optional.of(pairCache.get(key));
+        if (pairCacheByTokens.containsKey(key)) {
+            return Optional.of(pairCacheByTokens.get(key));
         }
         for (String factory : DexConstants.V2_FACTORIES) {
             Optional<PairMetadata> metadata = queryPair(factory, tokenA, tokenB);
             if (metadata.isPresent()) {
-                pairCache.put(key, metadata.get());
-                pairCache.put(buildPairKey(tokenB, tokenA), metadata.get());
+                cachePairMetadata(metadata.get(), true);
                 return metadata;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * 查找或创建 V3 池子信息
+     *
+     * @param tokenA 代币 A
+     * @param tokenB 代币 B
+     * @return 池子信息
+     */
+    public Optional<PairMetadata> findOrCreateV3Pool(String tokenA, String tokenB) {
+        for (String factory : DexConstants.V3_FACTORIES) {
+            for (BigInteger fee : DexConstants.V3_FEE_TIERS) {
+                String key = buildV3PoolKey(tokenA, tokenB, fee);
+                if (v3PoolCache.containsKey(key)) {
+                    return Optional.ofNullable(v3PoolCache.get(key));
+                }
+                Optional<PairMetadata> metadata = queryV3Pool(factory, tokenA, tokenB, fee);
+                if (metadata.isPresent()) {
+                    PairMetadata pairMetadata = metadata.get();
+                    v3PoolCache.put(key, pairMetadata);
+                    v3PoolCache.put(buildV3PoolKey(tokenB, tokenA, fee), pairMetadata);
+                    return metadata;
+                }
             }
         }
         return Optional.empty();
@@ -203,7 +233,7 @@ public class DexPriceService {
             if (isZeroAddress(pairAddress)) {
                 return Optional.empty();
             }
-            return loadPairMetadata(pairAddress);
+            return loadPairMetadata(pairAddress, true);
         } catch (IOException e) {
             log.error("Failed to query pair from factory {}", factory, e);
             return Optional.empty();
@@ -217,6 +247,25 @@ public class DexPriceService {
      * @return 元数据
      */
     public Optional<PairMetadata> loadPairMetadata(String pairAddress) {
+        return loadPairMetadata(pairAddress, true);
+    }
+
+    /**
+     * 加载池子元数据
+     *
+     * @param pairAddress   池子地址
+     * @param cacheByTokens 是否按 token 组合缓存
+     * @return 元数据
+     */
+    public Optional<PairMetadata> loadPairMetadata(String pairAddress, boolean cacheByTokens) {
+        String normalizedAddress = normalize(pairAddress);
+        if (pairCacheByAddress.containsKey(normalizedAddress)) {
+            PairMetadata metadata = pairCacheByAddress.get(normalizedAddress);
+            if (cacheByTokens) {
+                cachePairMetadata(metadata, true);
+            }
+            return Optional.of(metadata);
+        }
         try {
             String token0 = callAddressFunction(pairAddress, "token0");
             String token1 = callAddressFunction(pairAddress, "token1");
@@ -226,12 +275,28 @@ public class DexPriceService {
             BigInteger token0Decimals = fetchDecimals(token0);
             BigInteger token1Decimals = fetchDecimals(token1);
             PairMetadata metadata = new PairMetadata(pairAddress, token0, token1, token0Decimals, token1Decimals);
-            pairCache.put(buildPairKey(token0, token1), metadata);
-            pairCache.put(buildPairKey(token1, token0), metadata);
+            cachePairMetadata(metadata, cacheByTokens);
             return Optional.of(metadata);
         } catch (IOException e) {
             log.error("Failed to load pair metadata for {}", pairAddress, e);
             return Optional.empty();
+        }
+    }
+
+    /**
+     * 缓存池子元数据
+     *
+     * @param metadata      元数据
+     * @param cacheByTokens 是否按 token 缓存
+     */
+    private void cachePairMetadata(PairMetadata metadata, boolean cacheByTokens) {
+        if (metadata == null) {
+            return;
+        }
+        pairCacheByAddress.put(normalize(metadata.pairAddress), metadata);
+        if (cacheByTokens) {
+            pairCacheByTokens.put(buildPairKey(metadata.token0, metadata.token1), metadata);
+            pairCacheByTokens.put(buildPairKey(metadata.token1, metadata.token0), metadata);
         }
     }
 
@@ -286,6 +351,18 @@ public class DexPriceService {
     }
 
     /**
+     * 构建 V3 池子缓存键
+     *
+     * @param tokenA 代币 A
+     * @param tokenB 代币 B
+     * @param fee    费率
+     * @return 键值
+     */
+    private String buildV3PoolKey(String tokenA, String tokenB, BigInteger fee) {
+        return buildPairKey(tokenA, tokenB) + ":" + fee.toString();
+    }
+
+    /**
      * 地址归一化（小写）
      *
      * @param address 地址
@@ -293,6 +370,44 @@ public class DexPriceService {
      */
     private String normalize(String address) {
         return address == null ? null : address.toLowerCase();
+    }
+
+    /**
+     * 查询 V3 工厂获得池子
+     *
+     * @param factory 工厂地址
+     * @param tokenA  代币 A
+     * @param tokenB  代币 B
+     * @param fee     费率
+     * @return 池子信息
+     */
+    private Optional<PairMetadata> queryV3Pool(String factory, String tokenA, String tokenB, BigInteger fee) {
+        Function function = new Function(
+                "getPool",
+                Arrays.asList(new Address(normalize(tokenA)), new Address(normalize(tokenB)), new Uint24(fee)),
+                Collections.singletonList(new TypeReference<Address>() {
+                })
+        );
+        String encodedFunction = FunctionEncoder.encode(function);
+        Transaction tx = Transaction.createEthCallTransaction(null, factory, encodedFunction);
+        try {
+            EthCall response = web3j.ethCall(tx, DefaultBlockParameterName.LATEST).send();
+            if (response.isReverted()) {
+                return Optional.empty();
+            }
+            List<Type> values = FunctionReturnDecoder.decode(response.getValue(), function.getOutputParameters());
+            if (values.isEmpty()) {
+                return Optional.empty();
+            }
+            String poolAddress = values.get(0).getValue().toString();
+            if (isZeroAddress(poolAddress)) {
+                return Optional.empty();
+            }
+            return loadPairMetadata(poolAddress, false);
+        } catch (IOException e) {
+            log.error("Failed to query V3 pool from factory {} with fee {}", factory, fee, e);
+            return Optional.empty();
+        }
     }
 
     /**

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -127,15 +127,27 @@ public class LiquidityMonitorService {
     public void registerInitialPairs() {
         priceService.findOrCreatePair(tokenAddress, DexConstants.BUSD_ADDRESS)
                 .ifPresent(pair -> {
-                    registerPool(pair.pairAddress, pair.token0, pair.token1);
+                    registerPool(pair.pairAddress, pair.token0, pair.token1, false);
                     subscribeMint(pair.pairAddress, pair.token0, pair.token1, MINT_EVENT_V2);
                     subscribeBurn(pair.pairAddress, pair.token0, pair.token1, BURN_EVENT_V2);
                 });
         priceService.findOrCreatePair(tokenAddress, DexConstants.WBNB_ADDRESS)
                 .ifPresent(pair -> {
-                    registerPool(pair.pairAddress, pair.token0, pair.token1);
+                    registerPool(pair.pairAddress, pair.token0, pair.token1, false);
                     subscribeMint(pair.pairAddress, pair.token0, pair.token1, MINT_EVENT_V2);
                     subscribeBurn(pair.pairAddress, pair.token0, pair.token1, BURN_EVENT_V2);
+                });
+        priceService.findOrCreateV3Pool(tokenAddress, DexConstants.BUSD_ADDRESS)
+                .ifPresent(pool -> {
+                    registerPool(pool.pairAddress, pool.token0, pool.token1, true);
+                    subscribeMint(pool.pairAddress, pool.token0, pool.token1, MINT_EVENT_V3);
+                    subscribeBurn(pool.pairAddress, pool.token0, pool.token1, BURN_EVENT_V3);
+                });
+        priceService.findOrCreateV3Pool(tokenAddress, DexConstants.WBNB_ADDRESS)
+                .ifPresent(pool -> {
+                    registerPool(pool.pairAddress, pool.token0, pool.token1, true);
+                    subscribeMint(pool.pairAddress, pool.token0, pool.token1, MINT_EVENT_V3);
+                    subscribeBurn(pool.pairAddress, pool.token0, pool.token1, BURN_EVENT_V3);
                 });
     }
 
@@ -174,7 +186,7 @@ public class LiquidityMonitorService {
                 String pairAddress = data.get(0).getValue().toString();
                 BigInteger liquidity = (BigInteger) data.get(1).getValue();
                 if (matchesTarget(token0, token1)) {
-                    registerPool(pairAddress, token0, token1);
+                    registerPool(pairAddress, token0, token1, false);
                     log.info("PAIR_CREATED pair={} token0={} token1={} liquidity={} time={}", pairAddress, token0, token1, liquidity,
                             Instant.now());
                     subscribeMint(pairAddress, token0, token1, MINT_EVENT_V2);
@@ -194,7 +206,7 @@ public class LiquidityMonitorService {
                 BigInteger tickSpacing = (BigInteger) data.get(1).getValue();
                 String poolAddress = data.get(2).getValue().toString();
                 if (matchesTarget(token0, token1)) {
-                    registerPool(poolAddress, token0, token1);
+                    registerPool(poolAddress, token0, token1, true);
                     log.info("POOL_CREATED pool={} token0={} token1={} fee={} tickSpacing={} time={}",
                             poolAddress, token0, token1, fee, tickSpacing, Instant.now());
                     subscribeMint(poolAddress, token0, token1, MINT_EVENT_V3);
@@ -261,7 +273,7 @@ public class LiquidityMonitorService {
      */
     private void handleBurnLog(String pairAddress, String token0, String token1, Event event, Log logEntry) {
         try {
-            Optional<DexPriceService.PairMetadata> metadataOpt = priceService.loadPairMetadata(pairAddress);
+            Optional<DexPriceService.PairMetadata> metadataOpt = priceService.loadPairMetadata(pairAddress, event.equals(BURN_EVENT_V2));
             if (event.equals(BURN_EVENT_V2)) {
                 List<Type> data = FunctionReturnDecoder.decode(logEntry.getData(), event.getNonIndexedParameters());
                 if (data.size() < 2) {
@@ -324,7 +336,7 @@ public class LiquidityMonitorService {
                 }
                 BigInteger amount0 = (BigInteger) data.get(0).getValue();
                 BigInteger amount1 = (BigInteger) data.get(1).getValue();
-                Optional<DexPriceService.PairMetadata> metadataOpt = priceService.loadPairMetadata(pairAddress);
+                Optional<DexPriceService.PairMetadata> metadataOpt = priceService.loadPairMetadata(pairAddress, event.equals(MINT_EVENT_V2));
                 BigDecimal normalized0 = normalizeAmount(amount0, metadataOpt, true);
                 BigDecimal normalized1 = normalizeAmount(amount1, metadataOpt, false);
                 String sender = logEntry.getTopics().size() > 1 ? decodeAddress(logEntry.getTopics().get(1)) : "";
@@ -339,7 +351,7 @@ public class LiquidityMonitorService {
                 BigInteger liquidity = (BigInteger) data.get(1).getValue();
                 BigInteger amount0 = (BigInteger) data.get(2).getValue();
                 BigInteger amount1 = (BigInteger) data.get(3).getValue();
-                Optional<DexPriceService.PairMetadata> metadataOpt = priceService.loadPairMetadata(pairAddress);
+                Optional<DexPriceService.PairMetadata> metadataOpt = priceService.loadPairMetadata(pairAddress, false);
                 BigDecimal normalized0 = normalizeAmount(amount0, metadataOpt, true);
                 BigDecimal normalized1 = normalizeAmount(amount1, metadataOpt, false);
                 String owner = logEntry.getTopics().size() > 1 ? decodeAddress(logEntry.getTopics().get(1)) : "";
@@ -371,11 +383,11 @@ public class LiquidityMonitorService {
      * @param token0      token0 地址
      * @param token1      token1 地址
      */
-    private void registerPool(String pairAddress, String token0, String token1) {
+    private void registerPool(String pairAddress, String token0, String token1, boolean isV3) {
         if (pairAddress == null) {
             return;
         }
-        priceService.loadPairMetadata(pairAddress);
+        priceService.loadPairMetadata(pairAddress, !isV3);
         String normalized = pairAddress.toLowerCase();
         if (registeredPools.add(normalized)) {
             transferMonitorService.addLiquidityPair(pairAddress);


### PR DESCRIPTION
## Summary
- add configurable fee tiers for V3 factories and cache separation between V2 pairs and V3 pools
- implement helpers to discover and cache V3 pools while preserving existing V2 price lookups
- register initial V3 pools and ensure V3 liquidity events load metadata without polluting V2 caches

## Testing
- mvn -q -DskipTests compile *(fails: unable to download maven-resources-plugin due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d11aee90832682907b7aa358aff0