### PR TITLE
Handle monitoring of multiple V3 fee tier pools

### DIFF
--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -178,29 +178,37 @@ public class DexPriceService {
     }
 
     /**
-     * 查找或创建 V3 池子信息
+     * 查找或创建所有可用的 V3 池子信息
      *
      * @param tokenA 代币 A
      * @param tokenB 代币 B
-     * @return 池子信息
+     * @return 池子信息列表
      */
-    public Optional<PairMetadata> findOrCreateV3Pool(String tokenA, String tokenB) {
-        for (String factory : DexConstants.V3_FACTORIES) {
-            for (BigInteger fee : DexConstants.V3_FEE_TIERS) {
-                String key = buildV3PoolKey(tokenA, tokenB, fee);
-                if (v3PoolCache.containsKey(key)) {
-                    return Optional.ofNullable(v3PoolCache.get(key));
-                }
+    public List<PairMetadata> findOrCreateV3Pools(String tokenA, String tokenB) {
+        List<PairMetadata> pools = new ArrayList<>();
+        for (BigInteger fee : DexConstants.V3_FEE_TIERS) {
+            String key = buildV3PoolKey(tokenA, tokenB, fee);
+            PairMetadata cached = v3PoolCache.get(key);
+            if (cached != null) {
+                pools.add(cached);
+                continue;
+            }
+            for (String factory : DexConstants.V3_FACTORIES) {
                 Optional<PairMetadata> metadata = queryV3Pool(factory, tokenA, tokenB, fee);
                 if (metadata.isPresent()) {
                     PairMetadata pairMetadata = metadata.get();
                     v3PoolCache.put(key, pairMetadata);
                     v3PoolCache.put(buildV3PoolKey(tokenB, tokenA, fee), pairMetadata);
-                    return metadata;
+                    pools.add(pairMetadata);
+                    break;
                 }
             }
         }
-        return Optional.empty();
+        return pools;
+    }
+
+    public Optional<PairMetadata> findOrCreateV3Pool(String tokenA, String tokenB) {
+        return findOrCreateV3Pools(tokenA, tokenB).stream().findFirst();
     }
 
     /**

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -137,14 +137,14 @@ public class LiquidityMonitorService {
                     subscribeMint(pair.pairAddress, pair.token0, pair.token1, MINT_EVENT_V2);
                     subscribeBurn(pair.pairAddress, pair.token0, pair.token1, BURN_EVENT_V2);
                 });
-        priceService.findOrCreateV3Pool(tokenAddress, DexConstants.BUSD_ADDRESS)
-                .ifPresent(pool -> {
+        priceService.findOrCreateV3Pools(tokenAddress, DexConstants.BUSD_ADDRESS)
+                .forEach(pool -> {
                     registerPool(pool.pairAddress, pool.token0, pool.token1, true);
                     subscribeMint(pool.pairAddress, pool.token0, pool.token1, MINT_EVENT_V3);
                     subscribeBurn(pool.pairAddress, pool.token0, pool.token1, BURN_EVENT_V3);
                 });
-        priceService.findOrCreateV3Pool(tokenAddress, DexConstants.WBNB_ADDRESS)
-                .ifPresent(pool -> {
+        priceService.findOrCreateV3Pools(tokenAddress, DexConstants.WBNB_ADDRESS)
+                .forEach(pool -> {
                     registerPool(pool.pairAddress, pool.token0, pool.token1, true);
                     subscribeMint(pool.pairAddress, pool.token0, pool.token1, MINT_EVENT_V3);
                     subscribeBurn(pool.pairAddress, pool.token0, pool.token1, BURN_EVENT_V3);


### PR DESCRIPTION
## Summary
- update the V3 pool lookup to collect every available fee tier and cache the results per token pair
- seed the liquidity monitor with all discovered V3 pools while keeping the single-pool helper for compatibility

## Testing
- `mvn -q -DskipTests package` *(fails: 403 retrieving maven-resources-plugin from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e104627b8483268e6398babef1bc93