### PR TITLE
Implement Uniswap/Pancake v4 pool monitoring

### DIFF
--- a/src/main/java/com/example/monitor/DexConstants.java
+++ b/src/main/java/com/example/monitor/DexConstants.java
@@ -13,15 +13,15 @@ public class DexConstants {
     public static final String PANCAKE_V2_FACTORY = "0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73";
     /** PancakeSwap V3 工厂地址 */
     public static final String PANCAKE_V3_FACTORY = "0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865";
-    /** PancakeSwap V4 工厂地址（占位，若上线可替换真实地址） */
-    public static final String PANCAKE_V4_FACTORY = "0x0000000000000000000000000000000000000000";
+    /** PancakeSwap V4 PoolManager 地址（需根据正式部署更新） */
+    public static final String PANCAKE_V4_POOL_MANAGER = "0x0000000000000000000000000000000000000000";
 
     /** Uniswap V2 工厂地址（BSC 部署） */
     public static final String UNISWAP_V2_FACTORY = "0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6";
     /** Uniswap V3 工厂地址（BSC 部署占位） */
     public static final String UNISWAP_V3_FACTORY = "0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7";
-    /** Uniswap V4 工厂地址占位 */
-    public static final String UNISWAP_V4_FACTORY = "0x0000000000000000000000000000000000000000";
+    /** Uniswap V4 PoolManager 地址（需根据正式部署更新） */
+    public static final String UNISWAP_V4_POOL_MANAGER = "0x0000000000000000000000000000000000000000";
     //正式
     /** WBNB 代币地址 */
     public static final String WBNB_ADDRESS = "0xBB4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c";
@@ -48,10 +48,10 @@ public class DexConstants {
             BigInteger.valueOf(10000)     // 1%
     ));
 
-    /** PancakeSwap V4 工厂列表 */
-    public static final List<String> V4_FACTORIES = Collections.unmodifiableList(Arrays.asList(
-            PANCAKE_V4_FACTORY,
-            UNISWAP_V4_FACTORY
+    /** V4 PoolManager 列表 */
+    public static final List<String> V4_POOL_MANAGERS = Collections.unmodifiableList(Arrays.asList(
+            PANCAKE_V4_POOL_MANAGER,
+            UNISWAP_V4_POOL_MANAGER
     ));
 
     private DexConstants() {

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -321,7 +321,7 @@ public class DexPriceService {
     }
 
     public Optional<PriceRange> calculateTargetPriceRange(PairMetadata metadata, int tickLower, int tickUpper) {
-        if (metadata == null || metadata.poolType != PoolType.V3) {
+        if (metadata == null || (metadata.poolType != PoolType.V3 && metadata.poolType != PoolType.V4)) {
             return Optional.empty();
         }
         BigDecimal lowerRatio = priceFromTick(tickLower, metadata);
@@ -391,6 +391,7 @@ public class DexPriceService {
      */
     public List<PairMetadata> findOrCreateV3Pools(String tokenA, String tokenB) {
         List<PairMetadata> pools = new ArrayList<>();
+        List<String> concentratedFactories = new ArrayList<>(DexConstants.V3_FACTORIES);
         for (BigInteger fee : DexConstants.V3_FEE_TIERS) {
             String key = buildV3PoolKey(tokenA, tokenB, fee);
             PairMetadata cached = v3PoolCache.get(key);
@@ -398,7 +399,10 @@ public class DexPriceService {
                 pools.add(cached);
                 continue;
             }
-            for (String factory : DexConstants.V3_FACTORIES) {
+            for (String factory : concentratedFactories) {
+                if (factory == null || isZeroAddress(factory)) {
+                    continue;
+                }
                 Optional<PairMetadata> metadata = queryV3Pool(factory, tokenA, tokenB, fee);
                 if (metadata.isPresent()) {
                     PairMetadata pairMetadata = metadata.get();
@@ -750,7 +754,8 @@ public class DexPriceService {
      */
     public enum PoolType {
         V2,
-        V3
+        V3,
+        V4
     }
 
     /**
@@ -803,5 +808,38 @@ public class DexPriceService {
             String symbol1 = token1Symbol != null ? token1Symbol : token1;
             return symbol0.toLowerCase(java.util.Locale.ROOT) + "-" + symbol1.toLowerCase(java.util.Locale.ROOT);
         }
+    }
+
+    /**
+     * 基于 V4 PoolManager 事件直接构建并缓存池子元数据
+     *
+     * @param poolId  池子 ID（PoolId）
+     * @param token0  token0 地址
+     * @param token1  token1 地址
+     * @param fee     费率
+     * @return 元数据
+     */
+    public PairMetadata createOrUpdateV4PoolMetadata(String poolId, String token0, String token1, BigInteger fee) {
+        if (poolId == null || token0 == null || token1 == null) {
+            return null;
+        }
+        String normalizedPoolId = poolId.toLowerCase(Locale.ROOT);
+        PairMetadata existing = pairCacheByAddress.get(normalizedPoolId);
+        if (existing != null) {
+            PairMetadata updated = existing.withPoolType(PoolType.V4);
+            if (fee != null) {
+                updated = updated.withFee(fee);
+            }
+            cachePairMetadata(updated, false);
+            return updated;
+        }
+        BigInteger token0Decimals = fetchDecimals(token0);
+        BigInteger token1Decimals = fetchDecimals(token1);
+        String token0Symbol = fetchSymbol(token0);
+        String token1Symbol = fetchSymbol(token1);
+        PairMetadata metadata = new PairMetadata(poolId, token0, token1, token0Decimals, token1Decimals,
+                token0Symbol, token1Symbol, PoolType.V4, fee);
+        cachePairMetadata(metadata, false);
+        return metadata;
     }
 }

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -8,7 +8,9 @@ import org.web3j.abi.TypeReference;
 import org.web3j.abi.datatypes.Address;
 import org.web3j.abi.datatypes.Event;
 import org.web3j.abi.datatypes.Type;
+import org.web3j.abi.datatypes.generated.Bytes32;
 import org.web3j.abi.datatypes.generated.Int24;
+import org.web3j.abi.datatypes.generated.Int256;
 import org.web3j.abi.datatypes.generated.Uint128;
 import org.web3j.abi.datatypes.generated.Uint24;
 import org.web3j.abi.datatypes.generated.Uint256;
@@ -16,6 +18,7 @@ import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.request.EthFilter;
 import org.web3j.protocol.core.methods.response.Log;
+import org.web3j.utils.Numeric;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -24,6 +27,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,6 +52,8 @@ public class LiquidityMonitorService {
     private final Set<String> burnSubscribedPools = ConcurrentHashMap.newKeySet();
     /** 已订阅 Mint 事件的池子集合 */
     private final Set<String> mintSubscribedPools = ConcurrentHashMap.newKeySet();
+    /** V4 池子详情缓存 */
+    private final Map<String, V4PoolDetails> v4PoolDetails = new ConcurrentHashMap<>();
 
     /** V2 PairCreated 事件 */
     private static final Event PAIR_CREATED_EVENT = new Event("PairCreated",
@@ -60,6 +66,16 @@ public class LiquidityMonitorService {
     /** V3 PoolCreated 事件 */
     private static final Event POOL_CREATED_EVENT = new Event("PoolCreated",
             Arrays.asList(
+                    TypeReference.create(Address.class, true),
+                    TypeReference.create(Address.class, true),
+                    TypeReference.create(Uint24.class),
+                    TypeReference.create(Int24.class),
+                    TypeReference.create(Address.class)
+            ));
+    /** V4 PoolCreated 事件 */
+    private static final Event POOL_CREATED_EVENT_V4 = new Event("PoolCreated",
+            Arrays.asList(
+                    TypeReference.create(Bytes32.class, true),
                     TypeReference.create(Address.class, true),
                     TypeReference.create(Address.class, true),
                     TypeReference.create(Uint24.class),
@@ -102,6 +118,18 @@ public class LiquidityMonitorService {
                     TypeReference.create(Uint256.class),
                     TypeReference.create(Uint256.class)
             ));
+    /** V4 ModifyLiquidity 事件 */
+    private static final Event MODIFY_LIQUIDITY_EVENT_V4 = new Event("ModifyLiquidity",
+            Arrays.asList(
+                    TypeReference.create(Address.class, true),
+                    TypeReference.create(Bytes32.class, true),
+                    TypeReference.create(Int24.class),
+                    TypeReference.create(Int24.class),
+                    TypeReference.create(Int256.class),
+                    TypeReference.create(Int256.class),
+                    TypeReference.create(Int256.class),
+                    TypeReference.create(Bytes32.class)
+            ));
 
     /**
      * 构造函数
@@ -118,8 +146,26 @@ public class LiquidityMonitorService {
      * 启动监听
      */
     public void start() {
-        DexConstants.V2_FACTORIES.forEach(factory -> subscribeFactory(factory, PAIR_CREATED_EVENT));
-        DexConstants.V3_FACTORIES.forEach(factory -> subscribeFactory(factory, POOL_CREATED_EVENT));
+        DexConstants.V2_FACTORIES.stream()
+                .filter(this::isNonZeroAddress)
+                .forEach(factory -> subscribeFactory(factory, PAIR_CREATED_EVENT));
+        DexConstants.V3_FACTORIES.stream()
+                .filter(this::isNonZeroAddress)
+                .forEach(factory -> subscribeFactory(factory, POOL_CREATED_EVENT));
+        DexConstants.V4_POOL_MANAGERS.stream()
+                .filter(this::isNonZeroAddress)
+                .forEach(manager -> {
+                    subscribeFactory(manager, POOL_CREATED_EVENT_V4);
+                    subscribeFactory(manager, MODIFY_LIQUIDITY_EVENT_V4);
+                });
+    }
+
+    private boolean isNonZeroAddress(String address) {
+        if (address == null) {
+            return false;
+        }
+        String normalized = address.trim();
+        return !normalized.isEmpty() && !"0x0000000000000000000000000000000000000000".equalsIgnoreCase(normalized);
     }
 
     /**
@@ -238,9 +284,134 @@ public class LiquidityMonitorService {
                                 poolAddress, token0, token1, fee, tickSpacing, Instant.now());
                     }
                 }
+            } else if (event.equals(POOL_CREATED_EVENT_V4)) {
+                handleV4PoolCreated(logEntry);
+            } else if (event.equals(MODIFY_LIQUIDITY_EVENT_V4)) {
+                handleV4ModifyLiquidityLog(logEntry);
             }
         } catch (Exception ex) {
             log.error("Failed to handle factory log", ex);
+        }
+    }
+
+    private void handleV4PoolCreated(Log logEntry) {
+        List<String> topics = logEntry.getTopics();
+        if (topics.size() < 4) {
+            return;
+        }
+        String poolId = normalizePoolId(topics.get(1));
+        String token0 = decodeAddress(topics.get(2));
+        String token1 = decodeAddress(topics.get(3));
+        List<Type> data = FunctionReturnDecoder.decode(logEntry.getData(), POOL_CREATED_EVENT_V4.getNonIndexedParameters());
+        if (data.size() < 3) {
+            return;
+        }
+        BigInteger fee = ((Uint24) data.get(0)).getValue();
+        int tickSpacing = ((Int24) data.get(1)).getValue().intValue();
+        String hooks = ((Address) data.get(2)).getValue();
+        DexPriceService.PairMetadata metadata = priceService.createOrUpdateV4PoolMetadata(poolId, token0, token1, fee);
+        if (metadata == null) {
+            return;
+        }
+        registerPool(metadata);
+        String normalizedId = poolId.toLowerCase(Locale.ROOT);
+        v4PoolDetails.put(normalizedId, new V4PoolDetails(poolId, metadata, fee, tickSpacing, hooks));
+        log.info("POOL_CREATED_V4 poolId={} name={} token0={} token1={} fee={} tickSpacing={} hooks={} time={}",
+                poolId,
+                metadata.getDisplayName(),
+                token0,
+                token1,
+                formatFee(metadata.fee != null ? metadata.fee : fee),
+                tickSpacing,
+                hooks,
+                Instant.now());
+    }
+
+    private void handleV4ModifyLiquidityLog(Log logEntry) {
+        List<String> topics = logEntry.getTopics();
+        if (topics.size() < 3) {
+            return;
+        }
+        String sender = decodeAddress(topics.get(1));
+        String poolId = normalizePoolId(topics.get(2));
+        String normalizedId = poolId.toLowerCase(Locale.ROOT);
+        V4PoolDetails details = v4PoolDetails.get(normalizedId);
+        Optional<DexPriceService.PairMetadata> metadataOpt = priceService.loadPairMetadata(poolId,
+                false,
+                DexPriceService.PoolType.V4,
+                details != null ? details.fee : null);
+        if (!metadataOpt.isPresent() && details != null && details.metadata != null) {
+            metadataOpt = Optional.of(details.metadata);
+        }
+        if (!metadataOpt.isPresent()) {
+            return;
+        }
+        List<Type> data = FunctionReturnDecoder.decode(logEntry.getData(), MODIFY_LIQUIDITY_EVENT_V4.getNonIndexedParameters());
+        if (data.size() < 6) {
+            return;
+        }
+        int tickLower = ((Int24) data.get(0)).getValue().intValue();
+        int tickUpper = ((Int24) data.get(1)).getValue().intValue();
+        BigInteger liquidityDelta = ((Int256) data.get(2)).getValue();
+        BigInteger amount0Raw = ((Int256) data.get(3)).getValue();
+        BigInteger amount1Raw = ((Int256) data.get(4)).getValue();
+        BigInteger amount0 = amount0Raw.abs();
+        BigInteger amount1 = amount1Raw.abs();
+        BigDecimal normalized0 = normalizeAmount(amount0, metadataOpt, true);
+        BigDecimal normalized1 = normalizeAmount(amount1, metadataOpt, false);
+        Optional<DexPriceService.PriceRange> priceRangeOpt = metadataOpt.flatMap(meta ->
+                priceService.calculateTargetPriceRange(meta, tickLower, tickUpper));
+        String priceRange = formatPriceRange(priceRangeOpt);
+        DexPriceService.PairMetadata metadata = metadataOpt.get();
+        if (details == null || details.metadata != metadata) {
+            v4PoolDetails.put(normalizedId, new V4PoolDetails(poolId,
+                    metadata,
+                    metadata.fee != null ? metadata.fee : (details != null ? details.fee : null),
+                    details != null ? details.tickSpacing : 0,
+                    details != null ? details.hooks : ""));
+            details = v4PoolDetails.get(normalizedId);
+        }
+        String token0 = metadata.token0;
+        String token1 = metadata.token1;
+        String pairName = metadata.getDisplayName();
+        String feeText = formatFee(metadata.fee);
+        BigInteger liquidityAbs = liquidityDelta.abs();
+        String hooks = details != null ? details.hooks : "";
+        Instant now = Instant.now();
+        if (liquidityDelta.signum() >= 0) {
+            log.info("POOL_ADDED_V4 poolId={} name={} sender={} fee={} hooks={} token0={} token1={} tickLower={} tickUpper={} " +
+                            "liquidityDelta={} amount0={} amount1={} priceRange={} time={}",
+                    poolId,
+                    pairName,
+                    sender,
+                    feeText,
+                    hooks,
+                    token0,
+                    token1,
+                    tickLower,
+                    tickUpper,
+                    liquidityAbs,
+                    normalized0,
+                    normalized1,
+                    priceRange,
+                    now);
+        } else {
+            log.info("POOL_REMOVED_V4 poolId={} name={} sender={} fee={} hooks={} token0={} token1={} tickLower={} tickUpper=" +
+                            "{} liquidityDelta={} amount0={} amount1={} priceRange={} time={}",
+                    poolId,
+                    pairName,
+                    sender,
+                    feeText,
+                    hooks,
+                    token0,
+                    token1,
+                    tickLower,
+                    tickUpper,
+                    liquidityAbs,
+                    normalized0,
+                    normalized1,
+                    priceRange,
+                    now);
         }
     }
 
@@ -448,9 +619,16 @@ public class LiquidityMonitorService {
                 metadata.fee);
         String normalized = metadata.pairAddress.toLowerCase();
         if (registeredPools.add(normalized)) {
-            transferMonitorService.addLiquidityPair(metadata.pairAddress);
+            if (metadata.poolType != DexPriceService.PoolType.V4) {
+                transferMonitorService.addLiquidityPair(metadata.pairAddress);
+            }
             if (metadata.poolType == DexPriceService.PoolType.V3) {
                 log.info("POOL_REGISTERED pair={} name={} fee={}",
+                        metadata.pairAddress,
+                        metadata.getDisplayName(),
+                        formatFee(metadata.fee));
+            } else if (metadata.poolType == DexPriceService.PoolType.V4) {
+                log.info("POOL_REGISTERED_V4 poolId={} name={} fee={}",
                         metadata.pairAddress,
                         metadata.getDisplayName(),
                         formatFee(metadata.fee));
@@ -471,6 +649,17 @@ public class LiquidityMonitorService {
             clean = String.format("%40s", clean).replace(' ', '0');
         }
         return "0x" + clean.substring(clean.length() - 40);
+    }
+
+    private String normalizePoolId(String topic) {
+        if (topic == null) {
+            return "";
+        }
+        String clean = Numeric.cleanHexPrefix(topic).toLowerCase(Locale.ROOT);
+        if (clean.length() < 64) {
+            clean = String.format("%64s", clean).replace(' ', '0');
+        }
+        return "0x" + clean;
     }
 
     private String formatPairName(Optional<DexPriceService.PairMetadata> metadataOpt, String token0, String token1) {
@@ -517,5 +706,25 @@ public class LiquidityMonitorService {
                             .divide(BigDecimal.TEN.pow(decimals.intValue()), 8, RoundingMode.HALF_UP);
                 })
                 .orElseGet(() -> new BigDecimal(rawAmount));
+    }
+
+    private static class V4PoolDetails {
+        private final String poolId;
+        private final DexPriceService.PairMetadata metadata;
+        private final BigInteger fee;
+        private final int tickSpacing;
+        private final String hooks;
+
+        private V4PoolDetails(String poolId,
+                              DexPriceService.PairMetadata metadata,
+                              BigInteger fee,
+                              int tickSpacing,
+                              String hooks) {
+            this.poolId = poolId;
+            this.metadata = metadata;
+            this.fee = fee;
+            this.tickSpacing = tickSpacing;
+            this.hooks = hooks;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- subscribe to the Uniswap/Pancake v4 PoolManager contracts for PoolCreated and ModifyLiquidity events
- build V4 pool metadata and logs from PoolManager emissions instead of treating them like V3 pools
- allow V4 pool metadata to reuse price range calculations while keeping transfer tracking limited to addressable pools

## Testing
- mvn -q -DskipTests package *(fails: unable to download maven-resources-plugin due to HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e12d316e588326b5633a51c3a44070