### PR TITLE
Add V4 pool initialization logging and documentation

### DIFF
--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -9,6 +9,7 @@ import org.web3j.abi.datatypes.Address;
 import org.web3j.abi.datatypes.Bool;
 import org.web3j.abi.datatypes.Function;
 import org.web3j.abi.datatypes.Type;
+import org.web3j.abi.datatypes.generated.Bytes32;
 import org.web3j.abi.datatypes.generated.Int24;
 import org.web3j.abi.datatypes.generated.Uint112;
 import org.web3j.abi.datatypes.generated.Uint160;
@@ -65,9 +66,15 @@ public class DexPriceService {
     private final Map<String, PairMetadata> pairCacheByAddress = new ConcurrentHashMap<>();
     /** 按 token 与费率缓存的 V3 池子信息 */
     private final Map<String, PairMetadata> v3PoolCache = new ConcurrentHashMap<>();
+    /** 按 token 与费率缓存的 V4 池子信息 */
+    private final Map<String, PairMetadata> v4PoolCache = new ConcurrentHashMap<>();
 
     /** 价格计算精度 */
     private static final MathContext PRICE_MATH_CONTEXT = new MathContext(40, RoundingMode.HALF_UP);
+    /** 零地址常量 */
+    private static final String ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+    /** 空的 32 字节参数占位 */
+    private static final Bytes32 EMPTY_BYTES32 = new Bytes32(new byte[32]);
 
     /**
      * 构造函数
@@ -108,6 +115,14 @@ public class DexPriceService {
         return Optional.empty();
     }
 
+    /**
+     * 获取指定交易对的最佳价格
+     *
+     * @param baseToken  基础代币
+     * @param quoteToken 报价代币
+     * @param blockNumber 区块高度
+     * @return 最佳价格
+     */
     private Optional<BigDecimal> getBestPriceForPair(String baseToken, String quoteToken, BigInteger blockNumber) {
         List<PairMetadata> v2Pairs = findOrCreatePairs(baseToken, quoteToken);
         Optional<BigDecimal> v2Price = getBestPriceFromPairs(v2Pairs, baseToken, blockNumber);
@@ -115,9 +130,22 @@ public class DexPriceService {
             return v2Price;
         }
         List<PairMetadata> v3Pools = findOrCreateV3Pools(baseToken, quoteToken);
-        return getBestPriceFromPairs(v3Pools, baseToken, blockNumber);
+        Optional<BigDecimal> v3Price = getBestPriceFromPairs(v3Pools, baseToken, blockNumber);
+        if (v3Price.isPresent()) {
+            return v3Price;
+        }
+        List<PairMetadata> v4Pools = findOrCreateV4Pools(baseToken, quoteToken);
+        return getBestPriceFromPairs(v4Pools, baseToken, blockNumber);
     }
 
+    /**
+     * 从一组池子中选择最佳价格
+     *
+     * @param pairs       池子列表
+     * @param baseToken   基础代币
+     * @param blockNumber 区块高度
+     * @return 最佳价格
+     */
     private Optional<BigDecimal> getBestPriceFromPairs(List<PairMetadata> pairs, String baseToken, BigInteger blockNumber) {
         for (PairMetadata metadata : pairs) {
             Optional<BigDecimal> price = calculatePrice(metadata, baseToken, blockNumber);
@@ -136,12 +164,20 @@ public class DexPriceService {
         return Optional.empty();
     }
 
+    /**
+     * 根据池子类型计算价格
+     *
+     * @param metadata   池子元数据
+     * @param baseToken  基础代币
+     * @param blockNumber 区块高度
+     * @return 价格
+     */
     private Optional<BigDecimal> calculatePrice(PairMetadata metadata, String baseToken, BigInteger blockNumber) {
         if (metadata == null) {
             return Optional.empty();
         }
-        if (metadata.poolType == PoolType.V3) {
-            return calculateV3Price(metadata, baseToken, blockNumber);
+        if (metadata.poolType == PoolType.V3 || metadata.poolType == PoolType.V4) {
+            return calculateConcentratedLiquidityPrice(metadata, baseToken, blockNumber);
         }
         return calculateV2Price(metadata, baseToken, blockNumber);
     }
@@ -222,7 +258,15 @@ public class DexPriceService {
         return Optional.empty();
     }
 
-    private Optional<BigDecimal> calculateV3Price(PairMetadata pairMetadata, String baseToken, BigInteger blockNumber) {
+    /**
+     * 计算集中流动性池价格（V3/V4）
+     *
+     * @param pairMetadata 池子元数据
+     * @param baseToken    基础代币
+     * @param blockNumber  区块高度
+     * @return 价格
+     */
+    private Optional<BigDecimal> calculateConcentratedLiquidityPrice(PairMetadata pairMetadata, String baseToken, BigInteger blockNumber) {
         Optional<Slot0Data> slot0Opt = getSlot0(pairMetadata, blockNumber);
         if (!slot0Opt.isPresent()) {
             return Optional.empty();
@@ -248,6 +292,13 @@ public class DexPriceService {
         return Optional.empty();
     }
 
+    /**
+     * 查询集中流动性池的 slot0 数据
+     *
+     * @param pairMetadata 池子元数据
+     * @param blockNumber  区块高度
+     * @return slot0 数据
+     */
     private Optional<Slot0Data> getSlot0(PairMetadata pairMetadata, BigInteger blockNumber) {
         Function function = new Function(
                 "slot0",
@@ -290,6 +341,14 @@ public class DexPriceService {
         }
     }
 
+    /**
+     * 根据代币精度调整价格
+     *
+     * @param price           原始价格
+     * @param token0Decimals  token0 精度
+     * @param token1Decimals  token1 精度
+     * @return 调整后的价格
+     */
     private BigDecimal adjustForDecimals(BigDecimal price, BigInteger token0Decimals, BigInteger token1Decimals) {
         int diff = token0Decimals.intValue() - token1Decimals.intValue();
         if (diff == 0) {
@@ -302,6 +361,13 @@ public class DexPriceService {
         return price.divide(factor, PRICE_MATH_CONTEXT);
     }
 
+    /**
+     * 根据 tick 计算价格比率
+     *
+     * @param tick      tick 值
+     * @param metadata  池子元数据
+     * @return 价格比率
+     */
     private BigDecimal priceFromTick(int tick, PairMetadata metadata) {
         BigDecimal result = BigDecimal.ONE;
         BigDecimal base = BigDecimal.valueOf(1.0001);
@@ -321,7 +387,7 @@ public class DexPriceService {
     }
 
     public Optional<PriceRange> calculateTargetPriceRange(PairMetadata metadata, int tickLower, int tickUpper) {
-        if (metadata == null || metadata.poolType != PoolType.V3) {
+        if (metadata == null || (metadata.poolType != PoolType.V3 && metadata.poolType != PoolType.V4)) {
             return Optional.empty();
         }
         BigDecimal lowerRatio = priceFromTick(tickLower, metadata);
@@ -412,8 +478,56 @@ public class DexPriceService {
         return pools;
     }
 
+    /**
+     * 查找或创建单个 V3 池子
+     *
+     * @param tokenA 代币 A
+     * @param tokenB 代币 B
+     * @return 池子信息
+     */
     public Optional<PairMetadata> findOrCreateV3Pool(String tokenA, String tokenB) {
         return findOrCreateV3Pools(tokenA, tokenB).stream().findFirst();
+    }
+
+    /**
+     * 查找或创建所有可用的 V4 池子信息
+     *
+     * @param tokenA 代币 A
+     * @param tokenB 代币 B
+     * @return 池子信息列表
+     */
+    public List<PairMetadata> findOrCreateV4Pools(String tokenA, String tokenB) {
+        List<PairMetadata> pools = new ArrayList<>();
+        for (BigInteger fee : DexConstants.V3_FEE_TIERS) {
+            String key = buildV4PoolKey(tokenA, tokenB, fee);
+            PairMetadata cached = v4PoolCache.get(key);
+            if (cached != null) {
+                pools.add(cached);
+                continue;
+            }
+            for (String factory : DexConstants.V4_FACTORIES) {
+                Optional<PairMetadata> metadata = queryV4Pool(factory, tokenA, tokenB, fee);
+                if (metadata.isPresent()) {
+                    PairMetadata pairMetadata = metadata.get();
+                    v4PoolCache.put(key, pairMetadata);
+                    v4PoolCache.put(buildV4PoolKey(tokenB, tokenA, fee), pairMetadata);
+                    pools.add(pairMetadata);
+                    break;
+                }
+            }
+        }
+        return pools;
+    }
+
+    /**
+     * 查找或创建单个 V4 池子
+     *
+     * @param tokenA 代币 A
+     * @param tokenB 代币 B
+     * @return 池子信息
+     */
+    public Optional<PairMetadata> findOrCreateV4Pool(String tokenA, String tokenB) {
+        return findOrCreateV4Pools(tokenA, tokenB).stream().findFirst();
     }
 
     /**
@@ -463,14 +577,38 @@ public class DexPriceService {
         return loadPairMetadata(pairAddress, true, PoolType.V2, null);
     }
 
+    /**
+     * 加载池子元数据
+     *
+     * @param pairAddress    池子地址
+     * @param cacheByTokens  是否按代币缓存
+     * @return 元数据
+     */
     public Optional<PairMetadata> loadPairMetadata(String pairAddress, boolean cacheByTokens) {
         return loadPairMetadata(pairAddress, cacheByTokens, PoolType.V2, null);
     }
 
+    /**
+     * 加载池子元数据
+     *
+     * @param pairAddress    池子地址
+     * @param cacheByTokens  是否按代币缓存
+     * @param poolType       池子类型
+     * @return 元数据
+     */
     public Optional<PairMetadata> loadPairMetadata(String pairAddress, boolean cacheByTokens, PoolType poolType) {
         return loadPairMetadata(pairAddress, cacheByTokens, poolType, null);
     }
 
+    /**
+     * 加载池子元数据
+     *
+     * @param pairAddress    池子地址
+     * @param cacheByTokens  是否按代币缓存
+     * @param poolType       池子类型
+     * @param fee            池子费率
+     * @return 元数据
+     */
     public Optional<PairMetadata> loadPairMetadata(String pairAddress, boolean cacheByTokens, PoolType poolType, BigInteger fee) {
         String normalizedAddress = normalize(pairAddress);
         PairMetadata existing = pairCacheByAddress.get(normalizedAddress);
@@ -500,7 +638,7 @@ public class DexPriceService {
             String token0Symbol = fetchSymbol(token0);
             String token1Symbol = fetchSymbol(token1);
             PairMetadata metadata = new PairMetadata(pairAddress, token0, token1, token0Decimals, token1Decimals, token0Symbol, token1Symbol, poolType, fee);
-            if (metadata.poolType == PoolType.V3 && metadata.fee == null) {
+            if ((metadata.poolType == PoolType.V3 || metadata.poolType == PoolType.V4) && metadata.fee == null) {
                 metadata = metadata.withFee(fetchFee(pairAddress));
             }
             cachePairMetadata(metadata, cacheByTokens || poolType == PoolType.V2);
@@ -555,6 +693,13 @@ public class DexPriceService {
         }
     }
 
+    /**
+     * 将池子加入按代币缓存
+     *
+     * @param tokenA   代币 A
+     * @param tokenB   代币 B
+     * @param metadata 池子元数据
+     */
     private void addPairToTokenCache(String tokenA, String tokenB, PairMetadata metadata) {
         String key = buildPairKey(tokenA, tokenB);
         pairCacheByTokens.compute(key, (k, list) -> {
@@ -615,12 +760,24 @@ public class DexPriceService {
                 tokenInfoService.loadDecimals(token).orElse(BigInteger.valueOf(18)));
     }
 
+    /**
+     * 查询代币符号
+     *
+     * @param token 代币地址
+     * @return 代币符号
+     */
     private String fetchSymbol(String token) {
         String normalized = normalize(token);
         return symbolCache.computeIfAbsent(normalized, key ->
                 tokenInfoService.loadSymbol(token).orElse(normalized));
     }
 
+    /**
+     * 查询池子费率
+     *
+     * @param poolAddress 池子地址
+     * @return 费率
+     */
     private BigInteger fetchFee(String poolAddress) {
         Function function = new Function(
                 "fee",
@@ -667,6 +824,18 @@ public class DexPriceService {
      */
     private String buildV3PoolKey(String tokenA, String tokenB, BigInteger fee) {
         return buildPairKey(tokenA, tokenB) + ":" + fee.toString();
+    }
+
+    /**
+     * 构建 V4 池子缓存键
+     *
+     * @param tokenA 代币 A
+     * @param tokenB 代币 B
+     * @param fee    费率
+     * @return 键值
+     */
+    private String buildV4PoolKey(String tokenA, String tokenB, BigInteger fee) {
+        return "v4:" + buildPairKey(tokenA, tokenB) + ":" + fee.toString();
     }
 
     /**
@@ -718,6 +887,53 @@ public class DexPriceService {
     }
 
     /**
+     * 查询 V4 工厂获得池子
+     *
+     * @param factory 工厂地址
+     * @param tokenA  代币 A
+     * @param tokenB  代币 B
+     * @param fee     费率
+     * @return 池子信息
+     */
+    private Optional<PairMetadata> queryV4Pool(String factory, String tokenA, String tokenB, BigInteger fee) {
+        if (factory == null || isZeroAddress(factory)) {
+            return Optional.empty();
+        }
+        Function function = new Function(
+                "getPool",
+                Arrays.asList(
+                        new Address(normalize(tokenA)),
+                        new Address(normalize(tokenB)),
+                        new Uint24(fee),
+                        new Address(ZERO_ADDRESS),
+                        EMPTY_BYTES32
+                ),
+                Collections.singletonList(new TypeReference<Address>() {
+                })
+        );
+        String encodedFunction = FunctionEncoder.encode(function);
+        Transaction tx = Transaction.createEthCallTransaction(null, factory, encodedFunction);
+        try {
+            EthCall response = web3j.ethCall(tx, DefaultBlockParameterName.LATEST).send();
+            if (response.isReverted()) {
+                return Optional.empty();
+            }
+            List<Type> values = FunctionReturnDecoder.decode(response.getValue(), function.getOutputParameters());
+            if (values.isEmpty()) {
+                return Optional.empty();
+            }
+            String poolAddress = values.get(0).getValue().toString();
+            if (isZeroAddress(poolAddress)) {
+                return Optional.empty();
+            }
+            return loadPairMetadata(poolAddress, false, PoolType.V4, fee);
+        } catch (IOException e) {
+            log.error("Failed to query V4 pool from factory {} with fee {}", factory, fee, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
      * 判断地址是否为零地址
      *
      * @param address 地址
@@ -734,15 +950,31 @@ public class DexPriceService {
         private final BigDecimal reserve0;
         private final BigDecimal reserve1;
 
+        /**
+         * 构造储备数据
+         *
+         * @param reserve0 token0 储备
+         * @param reserve1 token1 储备
+         */
         private Reserves(BigDecimal reserve0, BigDecimal reserve1) {
             this.reserve0 = reserve0;
             this.reserve1 = reserve1;
         }
 
+        /**
+         * 获取 token0 储备
+         *
+         * @return token0 储备
+         */
         public BigDecimal getReserve0() {
             return reserve0;
         }
 
+        /**
+         * 获取 token1 储备
+         *
+         * @return token1 储备
+         */
         public BigDecimal getReserve1() {
             return reserve1;
         }
@@ -752,6 +984,12 @@ public class DexPriceService {
         private final BigInteger sqrtPriceX96;
         private final int tick;
 
+        /**
+         * 构造 slot0 数据
+         *
+         * @param sqrtPriceX96 当前 sqrtPriceX96
+         * @param tick         当前 tick
+         */
         private Slot0Data(BigInteger sqrtPriceX96, int tick) {
             this.sqrtPriceX96 = sqrtPriceX96;
             this.tick = tick;
@@ -765,6 +1003,12 @@ public class DexPriceService {
         public final BigDecimal lower;
         public final BigDecimal upper;
 
+        /**
+         * 构造价格区间
+         *
+         * @param lower 下限
+         * @param upper 上限
+         */
         public PriceRange(BigDecimal lower, BigDecimal upper) {
             this.lower = lower;
             this.upper = upper;
@@ -776,7 +1020,8 @@ public class DexPriceService {
      */
     public enum PoolType {
         V2,
-        V3
+        V3,
+        V4
     }
 
     /**
@@ -793,6 +1038,19 @@ public class DexPriceService {
         public final PoolType poolType;
         public final BigInteger fee;
 
+        /**
+         * 构造池子元数据
+         *
+         * @param pairAddress    池子地址
+         * @param token0         token0 地址
+         * @param token1         token1 地址
+         * @param token0Decimals token0 精度
+         * @param token1Decimals token1 精度
+         * @param token0Symbol   token0 符号
+         * @param token1Symbol   token1 符号
+         * @param poolType       池子类型
+         * @param fee            池子费率
+         */
         public PairMetadata(String pairAddress, String token0, String token1,
                              BigInteger token0Decimals, BigInteger token1Decimals,
                              String token0Symbol, String token1Symbol,
@@ -808,6 +1066,12 @@ public class DexPriceService {
             this.fee = fee;
         }
 
+        /**
+         * 生成新的池子元数据并替换类型
+         *
+         * @param poolType 新的池子类型
+         * @return 更新后的元数据
+         */
         public PairMetadata withPoolType(PoolType poolType) {
             if (poolType == null || this.poolType == poolType) {
                 return this;
@@ -816,6 +1080,12 @@ public class DexPriceService {
                     token0Symbol, token1Symbol, poolType, fee);
         }
 
+        /**
+         * 生成新的池子元数据并替换费率
+         *
+         * @param fee 新的费率
+         * @return 更新后的元数据
+         */
         public PairMetadata withFee(BigInteger fee) {
             if (fee == null || (this.fee != null && this.fee.equals(fee))) {
                 return this;
@@ -824,6 +1094,11 @@ public class DexPriceService {
                     token0Symbol, token1Symbol, poolType, fee);
         }
 
+        /**
+         * 获取显示名称
+         *
+         * @return 显示名称
+         */
         public String getDisplayName() {
             String symbol0 = token0Symbol != null ? token0Symbol : token0;
             String symbol1 = token1Symbol != null ? token1Symbol : token1;

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -130,6 +130,8 @@ public class LiquidityMonitorService {
                     TypeReference.create(Int256.class),
                     TypeReference.create(Bytes32.class)
             ));
+    /** 零地址常量 */
+    private static final String ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
     /**
      * 构造函数
@@ -181,6 +183,16 @@ public class LiquidityMonitorService {
                     registerPool(pool);
                     subscribeMint(pool, MINT_EVENT_V3);
                     subscribeBurn(pool, BURN_EVENT_V3);
+                });
+        priceService.findOrCreateV4Pools(tokenAddress, DexConstants.USDT_ADDRESS)
+                .forEach(pool -> {
+                    registerPool(pool);
+                    cacheV4Metadata(pool);
+                });
+        priceService.findOrCreateV4Pools(tokenAddress, DexConstants.WBNB_ADDRESS)
+                .forEach(pool -> {
+                    registerPool(pool);
+                    cacheV4Metadata(pool);
                 });
     }
 
@@ -463,6 +475,11 @@ public class LiquidityMonitorService {
         }
     }
 
+    /**
+     * 处理 V4 Initialize 日志
+     *
+     * @param logEntry 日志数据
+     */
     private void handleV4InitializeLog(Log logEntry) {
         List<String> topics = logEntry.getTopics();
         if (topics.size() < 4) {
@@ -503,6 +520,11 @@ public class LiquidityMonitorService {
                 Instant.now());
     }
 
+    /**
+     * 处理 V4 ModifyLiquidity 日志
+     *
+     * @param logEntry 日志数据
+     */
     private void handleV4ModifyLiquidityLog(Log logEntry) {
         List<String> topics = logEntry.getTopics();
         if (topics.size() < 2) {
@@ -571,7 +593,7 @@ public class LiquidityMonitorService {
         String normalized = metadata.pairAddress.toLowerCase();
         if (registeredPools.add(normalized)) {
             transferMonitorService.addLiquidityPair(metadata.pairAddress);
-            if (metadata.poolType == DexPriceService.PoolType.V3) {
+            if (metadata.poolType == DexPriceService.PoolType.V3 || metadata.poolType == DexPriceService.PoolType.V4) {
                 log.info("POOL_REGISTERED pair={} name={} fee={}",
                         metadata.pairAddress,
                         metadata.getDisplayName(),
@@ -585,6 +607,33 @@ public class LiquidityMonitorService {
     }
 
     /**
+     * 缓存 V4 池子元数据，便于后续事件处理
+     *
+     * @param metadata 池子元数据
+     */
+    private void cacheV4Metadata(DexPriceService.PairMetadata metadata) {
+        if (metadata == null || metadata.pairAddress == null) {
+            return;
+        }
+        String poolId = formatPoolId(metadata.pairAddress);
+        String normalizedId = normalizePoolId(poolId);
+        v4Pools.computeIfAbsent(normalizedId, key -> new V4PoolMetadata(
+                poolId,
+                metadata.token0,
+                metadata.token1,
+                metadata.token0Decimals,
+                metadata.token1Decimals,
+                metadata.token0Symbol,
+                metadata.token1Symbol,
+                metadata.fee,
+                "0x",
+                ZERO_ADDRESS,
+                BigInteger.ZERO,
+                0
+        ));
+    }
+
+    /**
      * 解码地址
      */
     private String decodeAddress(String topic) {
@@ -595,10 +644,22 @@ public class LiquidityMonitorService {
         return "0x" + clean.substring(clean.length() - 40);
     }
 
+    /**
+     * 解码 V4 币种地址
+     *
+     * @param topic 主题数据
+     * @return 地址
+     */
     private String decodeCurrency(String topic) {
         return decodeAddress(topic);
     }
 
+    /**
+     * 规范化池子 ID
+     *
+     * @param topic 主题数据
+     * @return 池子 ID
+     */
     private String formatPoolId(String topic) {
         if (topic == null || topic.isEmpty()) {
             return "";
@@ -606,6 +667,12 @@ public class LiquidityMonitorService {
         return topic.startsWith("0x") ? topic : "0x" + topic;
     }
 
+    /**
+     * 标准化池子 ID（小写）
+     *
+     * @param poolId 池子 ID
+     * @return 标准化后的池子 ID
+     */
     private String normalizePoolId(String poolId) {
         if (poolId == null || poolId.isEmpty()) {
             return "";
@@ -613,6 +680,12 @@ public class LiquidityMonitorService {
         return formatPoolId(poolId).toLowerCase(Locale.ROOT);
     }
 
+    /**
+     * 判断地址是否为零地址
+     *
+     * @param address 地址
+     * @return 是否为零地址
+     */
     private boolean isZeroAddress(String address) {
         if (address == null) {
             return true;
@@ -629,12 +702,26 @@ public class LiquidityMonitorService {
         return true;
     }
 
+    /**
+     * 构造池子显示名称
+     *
+     * @param metadataOpt 元数据
+     * @param token0      token0 地址
+     * @param token1      token1 地址
+     * @return 显示名称
+     */
     private String formatPairName(Optional<DexPriceService.PairMetadata> metadataOpt, String token0, String token1) {
         return metadataOpt
                 .map(DexPriceService.PairMetadata::getDisplayName)
                 .orElse((token0 + "-" + token1).toLowerCase(Locale.ROOT));
     }
 
+    /**
+     * 格式化费率
+     *
+     * @param fee 费率数值
+     * @return 文本
+     */
     private String formatFee(BigInteger fee) {
         if (fee == null) {
             return "unknown";
@@ -644,12 +731,24 @@ public class LiquidityMonitorService {
         return normalized.toPlainString() + "%";
     }
 
+    /**
+     * 格式化价格区间
+     *
+     * @param rangeOpt 区间
+     * @return 文本
+     */
     private String formatPriceRange(Optional<DexPriceService.PriceRange> rangeOpt) {
         return rangeOpt
                 .map(range -> String.format("[%s, %s]", formatDecimal(range.lower), formatDecimal(range.upper)))
                 .orElse("[]");
     }
 
+    /**
+     * 格式化十进制数
+     *
+     * @param value 数值
+     * @return 文本
+     */
     private String formatDecimal(BigDecimal value) {
         BigDecimal scaled = value.setScale(6, RoundingMode.HALF_UP);
         BigDecimal normalized = scaled.stripTrailingZeros();
@@ -690,6 +789,22 @@ public class LiquidityMonitorService {
         private BigInteger sqrtPriceX96;
         private int lastTick;
 
+        /**
+         * 构造 V4 池子元数据
+         *
+         * @param poolId          池子 ID
+         * @param token0          token0 地址
+         * @param token1          token1 地址
+         * @param token0Decimals  token0 精度
+         * @param token1Decimals  token1 精度
+         * @param token0Symbol    token0 符号
+         * @param token1Symbol    token1 符号
+         * @param fee             池子费率
+         * @param parametersHex   池子参数
+         * @param hooks           钩子合约地址
+         * @param sqrtPriceX96    当前 sqrtPriceX96
+         * @param tick            当前 tick
+         */
         private V4PoolMetadata(String poolId,
                                String token0,
                                String token1,
@@ -722,41 +837,82 @@ public class LiquidityMonitorService {
                     token1Decimals,
                     token0Symbol,
                     token1Symbol,
-                    DexPriceService.PoolType.V3,
+                    DexPriceService.PoolType.V4,
                     fee
             );
         }
 
+        /**
+         * 获取显示名称
+         *
+         * @return 显示名称
+         */
         private String getDisplayName() {
             String symbol0 = getSymbol0OrAddress();
             String symbol1 = getSymbol1OrAddress();
             return symbol0.toLowerCase(Locale.ROOT) + "-" + symbol1.toLowerCase(Locale.ROOT);
         }
 
+        /**
+         * 获取 token0 的符号或地址
+         *
+         * @return token0 标识
+         */
         private String getSymbol0OrAddress() {
             return token0Symbol != null ? token0Symbol : token0;
         }
 
+        /**
+         * 获取 token1 的符号或地址
+         *
+         * @return token1 标识
+         */
         private String getSymbol1OrAddress() {
             return token1Symbol != null ? token1Symbol : token1;
         }
 
+        /**
+         * 获取 token0 地址
+         *
+         * @return token0 地址
+         */
         private String getToken0() {
             return token0;
         }
 
+        /**
+         * 获取 token1 地址
+         *
+         * @return token1 地址
+         */
         private String getToken1() {
             return token1;
         }
 
+        /**
+         * 获取费率
+         *
+         * @return 费率
+         */
         private BigInteger getFee() {
             return fee;
         }
 
+        /**
+         * 转换为价格服务的元数据
+         *
+         * @return 池子元数据
+         */
         private DexPriceService.PairMetadata asPairMetadata() {
             return pairMetadata;
         }
 
+        /**
+         * 更新 slot0 数据
+         *
+         * @param sqrtPriceX96 新的 sqrtPriceX96
+         * @param tick         新的 tick
+         */
         private void updateSlot(BigInteger sqrtPriceX96, int tick) {
             this.sqrtPriceX96 = sqrtPriceX96;
             this.lastTick = tick;

--- a/src/main/java/com/example/monitor/TransferAggregator.java
+++ b/src/main/java/com/example/monitor/TransferAggregator.java
@@ -114,20 +114,42 @@ public class TransferAggregator {
         private final BigDecimal usdValue;
         private final Direction direction;
 
+        /**
+         * 构造转账记录
+         *
+         * @param timestamp 时间戳
+         * @param usdValue  美元价值
+         * @param direction 买卖方向
+         */
         public TransferRecord(long timestamp, BigDecimal usdValue, Direction direction) {
             this.timestamp = timestamp;
             this.usdValue = usdValue;
             this.direction = direction;
         }
 
+        /**
+         * 获取时间戳
+         *
+         * @return 时间戳
+         */
         public long getTimestamp() {
             return timestamp;
         }
 
+        /**
+         * 获取美元价值
+         *
+         * @return 美元价值
+         */
         public BigDecimal getUsdValue() {
             return usdValue;
         }
 
+        /**
+         * 获取转账方向
+         *
+         * @return 方向
+         */
         public Direction getDirection() {
             return direction;
         }


### PR DESCRIPTION
## Summary
- extend the DEX price service with Pancake/Uniswap v4 pool caching, lookups, and supporting documentation comments
- register and log discovered v4 pools during startup while caching metadata for later event handling
- add or correct documentation comments for helper methods and data classes such as the transfer aggregator

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central returned 403 for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e15a35ecc48326a3ba7ffa0aad91f3