### PR TITLE
Add Uniswap v4 liquidity monitoring

### DIFF
--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -653,6 +653,14 @@ public class DexPriceService {
         return address == null ? null : address.toLowerCase();
     }
 
+    public BigInteger resolveTokenDecimals(String token) {
+        return fetchDecimals(token);
+    }
+
+    public String resolveTokenSymbol(String token) {
+        return fetchSymbol(token);
+    }
+
     /**
      * 查询 V3 工厂获得池子
      *
@@ -750,7 +758,8 @@ public class DexPriceService {
      */
     public enum PoolType {
         V2,
-        V3
+        V3,
+        V4
     }
 
     /**

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -3,15 +3,21 @@ package com.example.monitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.web3j.abi.EventEncoder;
+import org.web3j.abi.FunctionEncoder;
 import org.web3j.abi.FunctionReturnDecoder;
 import org.web3j.abi.TypeReference;
 import org.web3j.abi.datatypes.Address;
+import org.web3j.abi.datatypes.DynamicBytes;
 import org.web3j.abi.datatypes.Event;
+import org.web3j.abi.datatypes.StaticStruct;
 import org.web3j.abi.datatypes.Type;
+import org.web3j.abi.datatypes.generated.Bytes32;
 import org.web3j.abi.datatypes.generated.Int24;
+import org.web3j.abi.datatypes.generated.Int256;
 import org.web3j.abi.datatypes.generated.Uint128;
 import org.web3j.abi.datatypes.generated.Uint24;
 import org.web3j.abi.datatypes.generated.Uint256;
+import org.web3j.crypto.Hash;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.request.EthFilter;
@@ -48,6 +54,10 @@ public class LiquidityMonitorService {
     private final Set<String> burnSubscribedPools = ConcurrentHashMap.newKeySet();
     /** 已订阅 Mint 事件的池子集合 */
     private final Set<String> mintSubscribedPools = ConcurrentHashMap.newKeySet();
+    /** 已知的 V4 池子元数据 */
+    private final ConcurrentHashMap<String, V4PoolMetadata> v4Pools = new ConcurrentHashMap<>();
+    /** 已订阅 V4 ModifyLiquidity 事件的池子集合 */
+    private final Set<String> v4SubscribedPools = ConcurrentHashMap.newKeySet();
 
     /** V2 PairCreated 事件 */
     private static final Event PAIR_CREATED_EVENT = new Event("PairCreated",
@@ -102,6 +112,30 @@ public class LiquidityMonitorService {
                     TypeReference.create(Uint256.class),
                     TypeReference.create(Uint256.class)
             ));
+    /** V4 Initialize 事件 */
+    private static final Event INITIALIZE_EVENT_V4 = new Event("Initialize",
+            Arrays.asList(
+                    TypeReference.create(Bytes32.class, true),
+                    TypeReference.create(Address.class),
+                    TypeReference.create(Address.class),
+                    TypeReference.create(Uint24.class),
+                    TypeReference.create(Int24.class),
+                    TypeReference.create(Address.class)
+            ));
+    /** V4 ModifyLiquidity 事件 */
+    private static final Event MODIFY_LIQUIDITY_EVENT_V4 = new Event("ModifyLiquidity",
+            Arrays.asList(
+                    TypeReference.create(Bytes32.class, true),
+                    TypeReference.create(Address.class),
+                    TypeReference.create(Int24.class),
+                    TypeReference.create(Int24.class),
+                    TypeReference.create(Int256.class),
+                    new TypeReference<BalanceDelta>() {
+                    },
+                    new TypeReference<BalanceDelta>() {
+                    },
+                    TypeReference.create(DynamicBytes.class)
+            ));
 
     /**
      * 构造函数
@@ -120,6 +154,7 @@ public class LiquidityMonitorService {
     public void start() {
         DexConstants.V2_FACTORIES.forEach(factory -> subscribeFactory(factory, PAIR_CREATED_EVENT));
         DexConstants.V3_FACTORIES.forEach(factory -> subscribeFactory(factory, POOL_CREATED_EVENT));
+        DexConstants.V4_FACTORIES.forEach(this::subscribeV4Factory);
     }
 
     /**
@@ -163,6 +198,13 @@ public class LiquidityMonitorService {
         filter.addSingleTopic(EventEncoder.encode(event));
         web3j.ethLogFlowable(filter).subscribe(logEntry -> handleFactoryLog(event, logEntry), throwable ->
                 log.error("Error processing factory event", throwable));
+    }
+
+    private void subscribeV4Factory(String factoryAddress) {
+        EthFilter initFilter = new EthFilter(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, factoryAddress);
+        initFilter.addSingleTopic(EventEncoder.encode(INITIALIZE_EVENT_V4));
+        web3j.ethLogFlowable(initFilter).subscribe(logEntry -> handleV4InitializeLog(factoryAddress, logEntry), throwable ->
+                log.error("Error processing V4 initialize event", throwable));
     }
 
     /**
@@ -241,6 +283,122 @@ public class LiquidityMonitorService {
             }
         } catch (Exception ex) {
             log.error("Failed to handle factory log", ex);
+        }
+    }
+
+    private void handleV4InitializeLog(String factoryAddress, Log logEntry) {
+        try {
+            List<String> topics = logEntry.getTopics();
+            if (topics.size() < 2) {
+                return;
+            }
+            String poolIdTopic = topics.get(1);
+            List<Type> data = FunctionReturnDecoder.decode(logEntry.getData(), INITIALIZE_EVENT_V4.getNonIndexedParameters());
+            if (data.size() < 5) {
+                return;
+            }
+            String currency0 = normalizeAddress(((Address) data.get(0)).getValue().toString());
+            String currency1 = normalizeAddress(((Address) data.get(1)).getValue().toString());
+            BigInteger fee = ((Uint24) data.get(2)).getValue();
+            BigInteger tickSpacing = ((Int24) data.get(3)).getValue();
+            String hooks = normalizeAddress(((Address) data.get(4)).getValue().toString());
+            if (!matchesTarget(currency0, currency1)) {
+                return;
+            }
+            String computedPoolId = computeV4PoolId(currency0, currency1, fee, tickSpacing, hooks);
+            String normalizedPoolId = normalizePoolId(poolIdTopic);
+            if (computedPoolId != null && !computedPoolId.equals(normalizedPoolId)) {
+                log.warn("V4 pool id mismatch manager={} topicId={} computedId={} currency0={} currency1={} fee={} tickSpacing={} hooks={}",
+                        factoryAddress,
+                        normalizedPoolId,
+                        computedPoolId,
+                        currency0,
+                        currency1,
+                        fee,
+                        tickSpacing,
+                        hooks);
+            }
+            V4PoolMetadata metadata = buildV4Metadata(factoryAddress, normalizedPoolId, currency0, currency1, fee, tickSpacing, hooks);
+            V4PoolMetadata previous = v4Pools.putIfAbsent(normalizedPoolId, metadata);
+            if (previous == null) {
+                log.info("POOL_INITIALIZED_V4 manager={} poolId={} name={} currency0={} currency1={} fee={} tickSpacing={} hooks={} time={}",
+                        factoryAddress,
+                        normalizedPoolId,
+                        metadata.getDisplayName(),
+                        currency0,
+                        currency1,
+                        formatFee(fee),
+                        tickSpacing,
+                        hooks,
+                        Instant.now());
+            }
+            subscribeV4ModifyLiquidity(factoryAddress, poolIdTopic);
+        } catch (Exception ex) {
+            log.error("Failed to handle V4 initialize log", ex);
+        }
+    }
+
+    private void subscribeV4ModifyLiquidity(String factoryAddress, String poolIdTopic) {
+        if (factoryAddress == null || poolIdTopic == null) {
+            return;
+        }
+        String normalizedPoolId = normalizePoolId(poolIdTopic);
+        String normalizedKey = normalizeAddress(factoryAddress) + ":" + normalizedPoolId;
+        if (!v4SubscribedPools.add(normalizedKey)) {
+            return;
+        }
+        EthFilter modifyFilter = new EthFilter(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, factoryAddress);
+        modifyFilter.addSingleTopic(EventEncoder.encode(MODIFY_LIQUIDITY_EVENT_V4));
+        modifyFilter.addOptionalTopics(normalizedPoolId);
+        web3j.ethLogFlowable(modifyFilter).subscribe(logEntry -> handleV4ModifyLiquidityLog(logEntry), throwable ->
+                log.error("Error processing V4 modify liquidity event", throwable));
+    }
+
+    private void handleV4ModifyLiquidityLog(Log logEntry) {
+        try {
+            List<String> topics = logEntry.getTopics();
+            if (topics.size() < 2) {
+                return;
+            }
+            String poolId = normalizePoolId(topics.get(1));
+            V4PoolMetadata metadata = v4Pools.get(poolId);
+            if (metadata == null) {
+                return;
+            }
+            List<Type> data = FunctionReturnDecoder.decode(logEntry.getData(), MODIFY_LIQUIDITY_EVENT_V4.getNonIndexedParameters());
+            if (data.size() < 7) {
+                return;
+            }
+            String sender = normalizeAddress(data.get(0).getValue().toString());
+            int tickLower = ((Int24) data.get(1)).getValue().intValue();
+            int tickUpper = ((Int24) data.get(2)).getValue().intValue();
+            BigInteger liquidityDelta = ((Int256) data.get(3)).getValue();
+            BalanceDelta callerDelta = (BalanceDelta) data.get(4);
+            BalanceDelta feesAccrued = (BalanceDelta) data.get(5);
+            BigDecimal amount0 = normalizeV4Amount(callerDelta.amount0.getValue(), metadata.currency0Decimals);
+            BigDecimal amount1 = normalizeV4Amount(callerDelta.amount1.getValue(), metadata.currency1Decimals);
+            BigDecimal fees0 = normalizeV4Amount(feesAccrued.amount0.getValue(), metadata.currency0Decimals);
+            BigDecimal fees1 = normalizeV4Amount(feesAccrued.amount1.getValue(), metadata.currency1Decimals);
+            int sign = liquidityDelta.signum();
+            String action = sign > 0 ? "POOL_ADDED_V4" : (sign < 0 ? "POOL_REMOVED_V4" : "POOL_UPDATED_V4");
+            log.info("{} manager={} poolId={} name={} sender={} currency0={} currency1={} tickLower={} tickUpper={} liquidityDelta={} amount0={} amount1={} fees0={} fees1={} time={}",
+                    action,
+                    metadata.manager,
+                    metadata.poolId,
+                    metadata.getDisplayName(),
+                    sender,
+                    metadata.currency0,
+                    metadata.currency1,
+                    tickLower,
+                    tickUpper,
+                    liquidityDelta,
+                    amount0,
+                    amount1,
+                    fees0,
+                    fees1,
+                    Instant.now());
+        } catch (Exception ex) {
+            log.error("Failed to handle V4 modify liquidity log", ex);
         }
     }
 
@@ -471,6 +629,144 @@ public class LiquidityMonitorService {
             clean = String.format("%40s", clean).replace(' ', '0');
         }
         return "0x" + clean.substring(clean.length() - 40);
+    }
+
+    private V4PoolMetadata buildV4Metadata(String manager,
+                                           String poolId,
+                                           String currency0,
+                                           String currency1,
+                                           BigInteger fee,
+                                           BigInteger tickSpacing,
+                                           String hooks) {
+        BigInteger token0Decimals = priceService.resolveTokenDecimals(currency0);
+        BigInteger token1Decimals = priceService.resolveTokenDecimals(currency1);
+        String symbol0 = priceService.resolveTokenSymbol(currency0);
+        String symbol1 = priceService.resolveTokenSymbol(currency1);
+        return new V4PoolMetadata(normalizeAddress(manager),
+                poolId,
+                currency0,
+                currency1,
+                fee,
+                tickSpacing,
+                hooks,
+                token0Decimals,
+                token1Decimals,
+                symbol0,
+                symbol1);
+    }
+
+    private String computeV4PoolId(String currency0,
+                                   String currency1,
+                                   BigInteger fee,
+                                   BigInteger tickSpacing,
+                                   String hooks) {
+        try {
+            String encoded = FunctionEncoder.encodeConstructor(Arrays.asList(
+                    new Address(currency0),
+                    new Address(currency1),
+                    new Uint24(fee),
+                    new Int24(tickSpacing),
+                    new Address(hooks)
+            ));
+            return normalizePoolId(Hash.sha3(encoded));
+        } catch (Exception ex) {
+            log.warn("Failed to compute V4 pool id currency0={} currency1={} fee={} tickSpacing={} hooks={}",
+                    currency0,
+                    currency1,
+                    fee,
+                    tickSpacing,
+                    hooks,
+                    ex);
+            return null;
+        }
+    }
+
+    private String normalizePoolId(String poolId) {
+        if (poolId == null) {
+            return null;
+        }
+        String clean = poolId.toLowerCase(Locale.ROOT);
+        if (!clean.startsWith("0x")) {
+            clean = "0x" + clean;
+        }
+        return clean;
+    }
+
+    private String normalizeAddress(String address) {
+        if (address == null) {
+            return null;
+        }
+        String clean = address.toLowerCase(Locale.ROOT);
+        if (!clean.startsWith("0x")) {
+            clean = "0x" + clean;
+        }
+        return clean;
+    }
+
+    private BigDecimal normalizeV4Amount(BigInteger rawAmount, BigInteger decimals) {
+        if (decimals == null) {
+            return new BigDecimal(rawAmount);
+        }
+        return new BigDecimal(rawAmount).divide(BigDecimal.TEN.pow(decimals.intValue()), 8, RoundingMode.HALF_UP);
+    }
+
+    private static class V4PoolMetadata {
+        private final String manager;
+        private final String poolId;
+        private final String currency0;
+        private final String currency1;
+        private final BigInteger fee;
+        private final BigInteger tickSpacing;
+        private final String hooks;
+        private final BigInteger currency0Decimals;
+        private final BigInteger currency1Decimals;
+        private final String currency0Symbol;
+        private final String currency1Symbol;
+
+        private V4PoolMetadata(String manager,
+                               String poolId,
+                               String currency0,
+                               String currency1,
+                               BigInteger fee,
+                               BigInteger tickSpacing,
+                               String hooks,
+                               BigInteger currency0Decimals,
+                               BigInteger currency1Decimals,
+                               String currency0Symbol,
+                               String currency1Symbol) {
+            this.manager = manager;
+            this.poolId = poolId;
+            this.currency0 = currency0;
+            this.currency1 = currency1;
+            this.fee = fee;
+            this.tickSpacing = tickSpacing;
+            this.hooks = hooks;
+            this.currency0Decimals = currency0Decimals;
+            this.currency1Decimals = currency1Decimals;
+            this.currency0Symbol = currency0Symbol;
+            this.currency1Symbol = currency1Symbol;
+        }
+
+        private String getDisplayName() {
+            String symbol0 = currency0Symbol != null ? currency0Symbol : currency0;
+            String symbol1 = currency1Symbol != null ? currency1Symbol : currency1;
+            return symbol0.toLowerCase(Locale.ROOT) + "-" + symbol1.toLowerCase(Locale.ROOT);
+        }
+    }
+
+    public static class BalanceDelta extends StaticStruct {
+        public final Int256 amount0;
+        public final Int256 amount1;
+
+        public BalanceDelta(Int256 amount0, Int256 amount1) {
+            super(amount0, amount1);
+            this.amount0 = amount0;
+            this.amount1 = amount1;
+        }
+
+        public BalanceDelta(List<Type> values) {
+            this((Int256) values.get(0), (Int256) values.get(1));
+        }
     }
 
     private String formatPairName(Optional<DexPriceService.PairMetadata> metadataOpt, String token0, String token1) {


### PR DESCRIPTION
## Summary
- expose helper accessors for token decimals and symbols and add a V4 pool type in the price service
- extend the liquidity monitor with Uniswap/PancakeSwap v4 initialize and modify-liquidity subscriptions, metadata tracking, and historical logging from the earliest block

## Testing
- mvn -q -DskipTests package *(fails: Maven Central returned 403 while downloading plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68e16a93a55083269cb4afc5f3a9f5fa