### PR TITLE
Limit V4 pool subscriptions to token creation block

### DIFF
--- a/src/main/java/com/example/monitor/BscTokenMonitor.java
+++ b/src/main/java/com/example/monitor/BscTokenMonitor.java
@@ -30,12 +30,18 @@ public class BscTokenMonitor {
         TokenInfoService tokenInfoService = new TokenInfoService(web3j);
         BigInteger decimals = tokenInfoService.loadDecimals(tokenAddress).orElse(BigInteger.valueOf(18));
         String symbol = tokenInfoService.loadSymbol(tokenAddress).orElse("TOKEN");
+        Optional<BigInteger> creationBlockOpt = tokenInfoService.findCreationBlock(tokenAddress);
+        if (creationBlockOpt.isPresent()) {
+            log.info("Detected token creation block={} for token={}", creationBlockOpt.get(), tokenAddress);
+        } else {
+            log.warn("Unable to determine creation block for token={}, defaulting to earliest block", tokenAddress);
+        }
         log.info("Starting monitor for token={} decimals={}", symbol, decimals);
 
         DexPriceService priceService = new DexPriceService(web3j, tokenAddress, decimals, symbol);
         TransferAggregator aggregator = new TransferAggregator();
         TransferMonitorService transferMonitorService = new TransferMonitorService(web3j, tokenAddress, decimals, symbol, priceService, aggregator);
-        LiquidityMonitorService liquidityMonitorService = new LiquidityMonitorService(web3j, tokenAddress, priceService, transferMonitorService);
+        LiquidityMonitorService liquidityMonitorService = new LiquidityMonitorService(web3j, tokenAddress, priceService, transferMonitorService, creationBlockOpt.orElse(null));
 
         liquidityMonitorService.registerInitialPairs();
         liquidityMonitorService.start();

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -19,6 +19,7 @@ import org.web3j.abi.datatypes.generated.Uint24;
 import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.crypto.Hash;
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.request.EthFilter;
 import org.web3j.protocol.core.methods.response.Log;
@@ -58,6 +59,8 @@ public class LiquidityMonitorService {
     private final ConcurrentHashMap<String, V4PoolMetadata> v4Pools = new ConcurrentHashMap<>();
     /** 已订阅 V4 ModifyLiquidity 事件的池子集合 */
     private final Set<String> v4SubscribedPools = ConcurrentHashMap.newKeySet();
+    /** 代币创建区块 */
+    private final BigInteger tokenCreationBlock;
 
     /** V2 PairCreated 事件 */
     private static final Event PAIR_CREATED_EVENT = new Event("PairCreated",
@@ -141,11 +144,12 @@ public class LiquidityMonitorService {
      * 构造函数
      */
     public LiquidityMonitorService(Web3j web3j, String tokenAddress, DexPriceService priceService,
-                                   TransferMonitorService transferMonitorService) {
+                                   TransferMonitorService transferMonitorService, BigInteger tokenCreationBlock) {
         this.web3j = web3j;
         this.tokenAddress = tokenAddress.toLowerCase();
         this.priceService = priceService;
         this.transferMonitorService = transferMonitorService;
+        this.tokenCreationBlock = tokenCreationBlock;
     }
 
     /**
@@ -201,7 +205,7 @@ public class LiquidityMonitorService {
     }
 
     private void subscribeV4Factory(String factoryAddress) {
-        EthFilter initFilter = new EthFilter(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, factoryAddress);
+        EthFilter initFilter = new EthFilter(getV4StartBlockParameter(), DefaultBlockParameterName.LATEST, factoryAddress);
         initFilter.addSingleTopic(EventEncoder.encode(INITIALIZE_EVENT_V4));
         web3j.ethLogFlowable(initFilter).subscribe(logEntry -> handleV4InitializeLog(factoryAddress, logEntry), throwable ->
                 log.error("Error processing V4 initialize event", throwable));
@@ -347,7 +351,7 @@ public class LiquidityMonitorService {
         if (!v4SubscribedPools.add(normalizedKey)) {
             return;
         }
-        EthFilter modifyFilter = new EthFilter(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, factoryAddress);
+        EthFilter modifyFilter = new EthFilter(getV4StartBlockParameter(), DefaultBlockParameterName.LATEST, factoryAddress);
         modifyFilter.addSingleTopic(EventEncoder.encode(MODIFY_LIQUIDITY_EVENT_V4));
         modifyFilter.addOptionalTopics(normalizedPoolId);
         web3j.ethLogFlowable(modifyFilter).subscribe(logEntry -> handleV4ModifyLiquidityLog(logEntry), throwable ->
@@ -701,6 +705,13 @@ public class LiquidityMonitorService {
             clean = "0x" + clean;
         }
         return clean;
+    }
+
+    private DefaultBlockParameter getV4StartBlockParameter() {
+        if (tokenCreationBlock != null && tokenCreationBlock.signum() >= 0) {
+            return DefaultBlockParameter.valueOf(tokenCreationBlock);
+        }
+        return DefaultBlockParameterName.EARLIEST;
     }
 
     private BigDecimal normalizeV4Amount(BigInteger rawAmount, BigInteger decimals) {

--- a/src/main/java/com/example/monitor/TokenInfoService.java
+++ b/src/main/java/com/example/monitor/TokenInfoService.java
@@ -10,9 +10,11 @@ import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.Utf8String;
 import org.web3j.abi.datatypes.generated.Uint8;
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.protocol.core.methods.response.EthCall;
+import org.web3j.protocol.core.methods.response.EthGetCode;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -74,6 +76,64 @@ public class TokenInfoService {
         return callSingleValueReturn(tokenAddress, function)
                 .map(value -> (Utf8String) value)
                 .map(Utf8String::getValue);
+    }
+
+    /**
+     * 查找代币合约的创建区块
+     *
+     * @param tokenAddress 代币合约地址
+     * @return 创建区块高度
+     */
+    public Optional<BigInteger> findCreationBlock(String tokenAddress) {
+        try {
+            BigInteger latestBlock = web3j.ethBlockNumber().send().getBlockNumber();
+            if (latestBlock == null) {
+                return Optional.empty();
+            }
+            BigInteger low = BigInteger.ZERO;
+            BigInteger high = latestBlock;
+            BigInteger creationBlock = null;
+            while (low.compareTo(high) <= 0) {
+                BigInteger mid = low.add(high).shiftRight(1);
+                if (hasContractCodeAtBlock(tokenAddress, mid)) {
+                    creationBlock = mid;
+                    if (mid.equals(BigInteger.ZERO)) {
+                        break;
+                    }
+                    high = mid.subtract(BigInteger.ONE);
+                } else {
+                    low = mid.add(BigInteger.ONE);
+                }
+            }
+            return Optional.ofNullable(creationBlock);
+        } catch (IOException e) {
+            log.error("Failed to determine creation block for token {}", tokenAddress, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 判断指定区块是否已经存在合约代码
+     *
+     * @param contractAddress 合约地址
+     * @param blockNumber     区块高度
+     * @return 是否存在代码
+     * @throws IOException RPC 调用异常
+     */
+    private boolean hasContractCodeAtBlock(String contractAddress, BigInteger blockNumber) throws IOException {
+        EthGetCode codeResponse = web3j.ethGetCode(contractAddress, DefaultBlockParameter.valueOf(blockNumber)).send();
+        if (codeResponse == null) {
+            return false;
+        }
+        if (codeResponse.hasError()) {
+            log.warn("eth_getCode returned error for contract={} block={} error={}",
+                    contractAddress,
+                    blockNumber,
+                    codeResponse.getError());
+            return false;
+        }
+        String code = codeResponse.getCode();
+        return code != null && !code.equalsIgnoreCase("0x") && !code.equalsIgnoreCase("0X");
     }
 
     /**


### PR DESCRIPTION
## Summary
- detect the monitored token's contract creation block via binary searching eth_getCode responses
- inject the creation block into the liquidity monitor so V4 subscriptions begin at that block instead of from genesis
- log the detected creation block (or fallback) when wiring services in the monitor entry point

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central returned 403 Forbidden for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e173ee4c5483268cc18cf97ed9db42