### PR TITLE
Enhance DEX pool logging and documentation

### DIFF
--- a/src/main/java/com/example/monitor/DexConstants.java
+++ b/src/main/java/com/example/monitor/DexConstants.java
@@ -3,7 +3,10 @@ package com.example.monitor;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * DEX 常量配置
@@ -53,6 +56,20 @@ public class DexConstants {
             PANCAKE_V4_FACTORY,
             UNISWAP_V4_FACTORY
     ));
+
+    /** 工厂地址与名称映射 */
+    public static final Map<String, String> FACTORY_NAMES;
+
+    static {
+        Map<String, String> names = new HashMap<>();
+        names.put(PANCAKE_V2_FACTORY.toLowerCase(Locale.ROOT), "PancakeSwap V2");
+        names.put(PANCAKE_V3_FACTORY.toLowerCase(Locale.ROOT), "PancakeSwap V3");
+        names.put(PANCAKE_V4_FACTORY.toLowerCase(Locale.ROOT), "PancakeSwap V4");
+        names.put(UNISWAP_V2_FACTORY.toLowerCase(Locale.ROOT), "Uniswap V2");
+        names.put(UNISWAP_V3_FACTORY.toLowerCase(Locale.ROOT), "Uniswap V3");
+        names.put(UNISWAP_V4_FACTORY.toLowerCase(Locale.ROOT), "Uniswap V4");
+        FACTORY_NAMES = Collections.unmodifiableMap(names);
+    }
 
     private DexConstants() {
     }

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -108,6 +108,14 @@ public class DexPriceService {
         return Optional.empty();
     }
 
+    /**
+     * 获取指定 token 对的最佳价格
+     *
+     * @param baseToken  基础代币
+     * @param quoteToken 报价代币
+     * @param blockNumber 区块高度
+     * @return 价格
+     */
     private Optional<BigDecimal> getBestPriceForPair(String baseToken, String quoteToken, BigInteger blockNumber) {
         List<PairMetadata> v2Pairs = findOrCreatePairs(baseToken, quoteToken);
         Optional<BigDecimal> v2Price = getBestPriceFromPairs(v2Pairs, baseToken, blockNumber);
@@ -118,6 +126,14 @@ public class DexPriceService {
         return getBestPriceFromPairs(v3Pools, baseToken, blockNumber);
     }
 
+    /**
+     * 遍历池子集合获取最佳价格
+     *
+     * @param pairs       池子列表
+     * @param baseToken   基础代币
+     * @param blockNumber 区块高度
+     * @return 价格
+     */
     private Optional<BigDecimal> getBestPriceFromPairs(List<PairMetadata> pairs, String baseToken, BigInteger blockNumber) {
         for (PairMetadata metadata : pairs) {
             Optional<BigDecimal> price = calculatePrice(metadata, baseToken, blockNumber);
@@ -128,6 +144,13 @@ public class DexPriceService {
         return Optional.empty();
     }
 
+    /**
+     * 合并两段价格路径
+     *
+     * @param first  第一路径
+     * @param second 第二路径
+     * @return 合并价格
+     */
     private Optional<BigDecimal> combinePrices(Optional<BigDecimal> first, Optional<BigDecimal> second) {
         if (first.isPresent() && second.isPresent()) {
             BigDecimal combined = first.get().multiply(second.get(), PRICE_MATH_CONTEXT);
@@ -136,6 +159,14 @@ public class DexPriceService {
         return Optional.empty();
     }
 
+    /**
+     * 计算指定池子的价格
+     *
+     * @param metadata    池子信息
+     * @param baseToken   基础代币
+     * @param blockNumber 区块高度
+     * @return 价格
+     */
     private Optional<BigDecimal> calculatePrice(PairMetadata metadata, String baseToken, BigInteger blockNumber) {
         if (metadata == null) {
             return Optional.empty();
@@ -222,6 +253,14 @@ public class DexPriceService {
         return Optional.empty();
     }
 
+    /**
+     * 计算 V3 池子价格
+     *
+     * @param pairMetadata 池子信息
+     * @param baseToken    基础代币
+     * @param blockNumber  区块高度
+     * @return 价格
+     */
     private Optional<BigDecimal> calculateV3Price(PairMetadata pairMetadata, String baseToken, BigInteger blockNumber) {
         Optional<Slot0Data> slot0Opt = getSlot0(pairMetadata, blockNumber);
         if (!slot0Opt.isPresent()) {
@@ -248,6 +287,13 @@ public class DexPriceService {
         return Optional.empty();
     }
 
+    /**
+     * 查询 slot0 数据
+     *
+     * @param pairMetadata 池子信息
+     * @param blockNumber  区块高度
+     * @return slot0 数据
+     */
     private Optional<Slot0Data> getSlot0(PairMetadata pairMetadata, BigInteger blockNumber) {
         Function function = new Function(
                 "slot0",
@@ -290,6 +336,14 @@ public class DexPriceService {
         }
     }
 
+    /**
+     * 根据精度调整价格
+     *
+     * @param price           原始价格
+     * @param token0Decimals token0 精度
+     * @param token1Decimals token1 精度
+     * @return 调整后的价格
+     */
     private BigDecimal adjustForDecimals(BigDecimal price, BigInteger token0Decimals, BigInteger token1Decimals) {
         int diff = token0Decimals.intValue() - token1Decimals.intValue();
         if (diff == 0) {
@@ -302,6 +356,13 @@ public class DexPriceService {
         return price.divide(factor, PRICE_MATH_CONTEXT);
     }
 
+    /**
+     * 根据 tick 计算价格
+     *
+     * @param tick     tick 值
+     * @param metadata 池子信息
+     * @return 价格
+     */
     private BigDecimal priceFromTick(int tick, PairMetadata metadata) {
         BigDecimal result = BigDecimal.ONE;
         BigDecimal base = BigDecimal.valueOf(1.0001);
@@ -320,6 +381,14 @@ public class DexPriceService {
         return result;
     }
 
+    /**
+     * 计算目标代币在给定 tick 区间内的价格范围
+     *
+     * @param metadata  池子信息
+     * @param tickLower 下界 tick
+     * @param tickUpper 上界 tick
+     * @return 价格区间
+     */
     public Optional<PriceRange> calculateTargetPriceRange(PairMetadata metadata, int tickLower, int tickUpper) {
         if (metadata == null || metadata.poolType != PoolType.V3) {
             return Optional.empty();
@@ -412,6 +481,13 @@ public class DexPriceService {
         return pools;
     }
 
+    /**
+     * 查找或创建任意费率的 V3 池子
+     *
+     * @param tokenA 代币 A
+     * @param tokenB 代币 B
+     * @return 池子信息
+     */
     public Optional<PairMetadata> findOrCreateV3Pool(String tokenA, String tokenB) {
         return findOrCreateV3Pools(tokenA, tokenB).stream().findFirst();
     }
@@ -463,14 +539,38 @@ public class DexPriceService {
         return loadPairMetadata(pairAddress, true, PoolType.V2, null);
     }
 
+    /**
+     * 加载池子元数据
+     *
+     * @param pairAddress    池子地址
+     * @param cacheByTokens  是否按 token 缓存
+     * @return 元数据
+     */
     public Optional<PairMetadata> loadPairMetadata(String pairAddress, boolean cacheByTokens) {
         return loadPairMetadata(pairAddress, cacheByTokens, PoolType.V2, null);
     }
 
+    /**
+     * 加载池子元数据
+     *
+     * @param pairAddress    池子地址
+     * @param cacheByTokens  是否按 token 缓存
+     * @param poolType       池子类型
+     * @return 元数据
+     */
     public Optional<PairMetadata> loadPairMetadata(String pairAddress, boolean cacheByTokens, PoolType poolType) {
         return loadPairMetadata(pairAddress, cacheByTokens, poolType, null);
     }
 
+    /**
+     * 加载池子元数据
+     *
+     * @param pairAddress    池子地址
+     * @param cacheByTokens  是否按 token 缓存
+     * @param poolType       池子类型
+     * @param fee            费率
+     * @return 元数据
+     */
     public Optional<PairMetadata> loadPairMetadata(String pairAddress, boolean cacheByTokens, PoolType poolType, BigInteger fee) {
         String normalizedAddress = normalize(pairAddress);
         PairMetadata existing = pairCacheByAddress.get(normalizedAddress);
@@ -499,7 +599,9 @@ public class DexPriceService {
             BigInteger token1Decimals = fetchDecimals(token1);
             String token0Symbol = fetchSymbol(token0);
             String token1Symbol = fetchSymbol(token1);
-            PairMetadata metadata = new PairMetadata(pairAddress, token0, token1, token0Decimals, token1Decimals, token0Symbol, token1Symbol, poolType, fee);
+            String factoryAddress = callAddressFunction(pairAddress, "factory");
+            String swapName = resolveFactoryName(factoryAddress);
+            PairMetadata metadata = new PairMetadata(pairAddress, token0, token1, token0Decimals, token1Decimals, token0Symbol, token1Symbol, poolType, fee, factoryAddress, swapName);
             if (metadata.poolType == PoolType.V3 && metadata.fee == null) {
                 metadata = metadata.withFee(fetchFee(pairAddress));
             }
@@ -529,6 +631,13 @@ public class DexPriceService {
         }
     }
 
+    /**
+     * 将池子加入 token 缓存
+     *
+     * @param tokenA    代币 A
+     * @param tokenB    代币 B
+     * @param metadata  池子信息
+     */
     private void addPairToTokenCache(String tokenA, String tokenB, PairMetadata metadata) {
         String key = buildPairKey(tokenA, tokenB);
         pairCacheByTokens.compute(key, (k, list) -> {
@@ -589,12 +698,37 @@ public class DexPriceService {
                 tokenInfoService.loadDecimals(token).orElse(BigInteger.valueOf(18)));
     }
 
+    /**
+     * 查询代币符号
+     *
+     * @param token 代币地址
+     * @return 代币符号
+     */
     private String fetchSymbol(String token) {
         String normalized = normalize(token);
         return symbolCache.computeIfAbsent(normalized, key ->
                 tokenInfoService.loadSymbol(token).orElse(normalized));
     }
 
+    /**
+     * 解析工厂名称
+     *
+     * @param factoryAddress 工厂地址
+     * @return 交易所名称
+     */
+    private String resolveFactoryName(String factoryAddress) {
+        if (factoryAddress == null) {
+            return null;
+        }
+        return DexConstants.FACTORY_NAMES.get(factoryAddress.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * 查询池子费率
+     *
+     * @param poolAddress 池子地址
+     * @return 费率
+     */
     private BigInteger fetchFee(String poolAddress) {
         Function function = new Function(
                 "fee",
@@ -618,6 +752,125 @@ public class DexPriceService {
             log.error("Failed to fetch fee for pool {}", poolAddress, e);
             return null;
         }
+    }
+
+    /**
+     * 查询池子持有的代币余额并转换为标准精度
+     *
+     * @param tokenAddress 代币地址
+     * @param decimals     代币精度
+     * @param holder       池子地址
+     * @return 标准化余额
+     */
+    private Optional<BigDecimal> fetchTokenBalance(String tokenAddress, BigInteger decimals, String holder) {
+        if (tokenAddress == null || holder == null) {
+            return Optional.empty();
+        }
+        Optional<BigInteger> balanceOpt = tokenInfoService.loadBalance(tokenAddress, holder);
+        if (!balanceOpt.isPresent()) {
+            return Optional.empty();
+        }
+        int scale = decimals != null ? decimals.intValue() : 18;
+        if (scale < 0) {
+            scale = 0;
+        }
+        BigDecimal divisor = BigDecimal.TEN.pow(scale);
+        if (divisor.compareTo(BigDecimal.ZERO) == 0) {
+            return Optional.empty();
+        }
+        BigDecimal normalized = new BigDecimal(balanceOpt.get())
+                .divide(divisor, 18, RoundingMode.HALF_UP);
+        return Optional.of(normalized);
+    }
+
+    /**
+     * 查询 V3 池子的 tickSpacing
+     *
+     * @param metadata 池子元数据
+     * @return tickSpacing
+     */
+    private Optional<Integer> fetchTickSpacing(PairMetadata metadata) {
+        if (metadata == null || metadata.poolType != PoolType.V3) {
+            return Optional.empty();
+        }
+        Function function = new Function(
+                "tickSpacing",
+                Collections.emptyList(),
+                Collections.singletonList(new TypeReference<Int24>() {
+                })
+        );
+        String data = FunctionEncoder.encode(function);
+        Transaction tx = Transaction.createEthCallTransaction(null, metadata.pairAddress, data);
+        try {
+            EthCall response = web3j.ethCall(tx, DefaultBlockParameterName.LATEST).send();
+            if (response.isReverted()) {
+                return Optional.empty();
+            }
+            List<Type> values = FunctionReturnDecoder.decode(response.getValue(), function.getOutputParameters());
+            if (values.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(((Int24) values.get(0)).getValue().intValue());
+        } catch (IOException e) {
+            log.error("Failed to query tickSpacing for pool {}", metadata.pairAddress, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 查询最新区块高度
+     *
+     * @return 最新区块
+     */
+    private Optional<BigInteger> fetchLatestBlockNumber() {
+        try {
+            return Optional.ofNullable(web3j.ethBlockNumber().send().getBlockNumber());
+        } catch (IOException e) {
+            log.error("Failed to fetch latest block number", e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 加载池子当前快照信息
+     *
+     * @param metadata 池子元数据
+     * @return 池子快照
+     */
+    public Optional<PoolSnapshot> loadPoolSnapshot(PairMetadata metadata) {
+        if (metadata == null || metadata.pairAddress == null) {
+            return Optional.empty();
+        }
+        Optional<BigDecimal> token0BalanceOpt = fetchTokenBalance(metadata.token0, metadata.token0Decimals, metadata.pairAddress);
+        Optional<BigDecimal> token1BalanceOpt = fetchTokenBalance(metadata.token1, metadata.token1Decimals, metadata.pairAddress);
+        BigDecimal priceToken1PerToken0 = null;
+        if (token0BalanceOpt.isPresent() && token1BalanceOpt.isPresent()
+                && token0BalanceOpt.get().compareTo(BigDecimal.ZERO) > 0) {
+            priceToken1PerToken0 = token1BalanceOpt.get()
+                    .divide(token0BalanceOpt.get(), 18, RoundingMode.HALF_UP);
+        }
+        Integer currentTick = null;
+        BigInteger sqrtPriceX96 = null;
+        Integer tickSpacing = null;
+        if (metadata.poolType == PoolType.V3) {
+            Optional<BigInteger> blockNumberOpt = fetchLatestBlockNumber();
+            if (blockNumberOpt.isPresent()) {
+                Optional<Slot0Data> slot0Opt = getSlot0(metadata, blockNumberOpt.get());
+                if (slot0Opt.isPresent()) {
+                    Slot0Data slot0 = slot0Opt.get();
+                    currentTick = slot0.tick;
+                    sqrtPriceX96 = slot0.sqrtPriceX96;
+                }
+            }
+            tickSpacing = fetchTickSpacing(metadata).orElse(null);
+        }
+        return Optional.of(new PoolSnapshot(
+                token0BalanceOpt.orElse(null),
+                token1BalanceOpt.orElse(null),
+                priceToken1PerToken0,
+                currentTick,
+                tickSpacing,
+                sqrtPriceX96));
     }
 
     /**
@@ -653,10 +906,22 @@ public class DexPriceService {
         return address == null ? null : address.toLowerCase();
     }
 
+    /**
+     * 获取代币精度
+     *
+     * @param token 代币地址
+     * @return 精度
+     */
     public BigInteger resolveTokenDecimals(String token) {
         return fetchDecimals(token);
     }
 
+    /**
+     * 获取代币符号
+     *
+     * @param token 代币地址
+     * @return 符号
+     */
     public String resolveTokenSymbol(String token) {
         return fetchSymbol(token);
     }
@@ -710,6 +975,58 @@ public class DexPriceService {
     }
 
     /**
+     * 池子快照数据
+     */
+    public static class PoolSnapshot {
+        /** token0 数量（标准精度） */
+        public final BigDecimal token0Amount;
+        /** token1 数量（标准精度） */
+        public final BigDecimal token1Amount;
+        /** token1/token0 价格 */
+        public final BigDecimal priceToken1PerToken0;
+        /** 当前 tick */
+        public final Integer currentTick;
+        /** tickSpacing */
+        public final Integer tickSpacing;
+        /** 当前 sqrtPriceX96 */
+        public final BigInteger sqrtPriceX96;
+
+        public PoolSnapshot(BigDecimal token0Amount,
+                            BigDecimal token1Amount,
+                            BigDecimal priceToken1PerToken0,
+                            Integer currentTick,
+                            Integer tickSpacing,
+                            BigInteger sqrtPriceX96) {
+            this.token0Amount = token0Amount;
+            this.token1Amount = token1Amount;
+            this.priceToken1PerToken0 = priceToken1PerToken0;
+            this.currentTick = currentTick;
+            this.tickSpacing = tickSpacing;
+            this.sqrtPriceX96 = sqrtPriceX96;
+        }
+
+        /**
+         * 计算指定代币的价格
+         *
+         * @param baseToken 代币地址
+         * @param metadata  池子元数据
+         * @return 价格
+         */
+        public Optional<BigDecimal> priceForToken(String baseToken, PairMetadata metadata) {
+            if (metadata == null || priceToken1PerToken0 == null || baseToken == null) {
+                return Optional.empty();
+            }
+            if (metadata.token0.equalsIgnoreCase(baseToken)) {
+                return Optional.of(priceToken1PerToken0);
+            }
+            if (metadata.token1.equalsIgnoreCase(baseToken) && priceToken1PerToken0.compareTo(BigDecimal.ZERO) > 0) {
+                return Optional.of(BigDecimal.ONE.divide(priceToken1PerToken0, 18, RoundingMode.HALF_UP));
+            }
+            return Optional.empty();
+        }
+    }
+
+    /**
      * 储备数据结构
      */
     private static class Reserves {
@@ -721,17 +1038,32 @@ public class DexPriceService {
             this.reserve1 = reserve1;
         }
 
+        /**
+         * 获取 token0 储备
+         *
+         * @return 储备
+         */
         public BigDecimal getReserve0() {
             return reserve0;
         }
 
+        /**
+         * 获取 token1 储备
+         *
+         * @return 储备
+         */
         public BigDecimal getReserve1() {
             return reserve1;
         }
     }
 
+    /**
+     * slot0 数据结构
+     */
     private static class Slot0Data {
+        /** sqrtPrice 值 */
         private final BigInteger sqrtPriceX96;
+        /** 当前 tick */
         private final int tick;
 
         private Slot0Data(BigInteger sqrtPriceX96, int tick) {
@@ -766,20 +1098,34 @@ public class DexPriceService {
      * 池子元数据
      */
     public static class PairMetadata {
+        /** 池子合约地址 */
         public final String pairAddress;
+        /** token0 地址 */
         public final String token0;
+        /** token1 地址 */
         public final String token1;
+        /** token0 精度 */
         public final BigInteger token0Decimals;
+        /** token1 精度 */
         public final BigInteger token1Decimals;
+        /** token0 符号 */
         public final String token0Symbol;
+        /** token1 符号 */
         public final String token1Symbol;
+        /** 池子类型 */
         public final PoolType poolType;
+        /** 费率 */
         public final BigInteger fee;
+        /** 工厂地址 */
+        public final String factoryAddress;
+        /** 交易所名称 */
+        public final String swapName;
 
         public PairMetadata(String pairAddress, String token0, String token1,
                              BigInteger token0Decimals, BigInteger token1Decimals,
                              String token0Symbol, String token1Symbol,
-                             PoolType poolType, BigInteger fee) {
+                             PoolType poolType, BigInteger fee,
+                             String factoryAddress, String swapName) {
             this.pairAddress = pairAddress;
             this.token0 = token0;
             this.token1 = token1;
@@ -789,6 +1135,8 @@ public class DexPriceService {
             this.token1Symbol = token1Symbol;
             this.poolType = poolType == null ? PoolType.V2 : poolType;
             this.fee = fee;
+            this.factoryAddress = factoryAddress;
+            this.swapName = swapName;
         }
 
         public PairMetadata withPoolType(PoolType poolType) {
@@ -796,7 +1144,7 @@ public class DexPriceService {
                 return this;
             }
             return new PairMetadata(pairAddress, token0, token1, token0Decimals, token1Decimals,
-                    token0Symbol, token1Symbol, poolType, fee);
+                    token0Symbol, token1Symbol, poolType, fee, factoryAddress, swapName);
         }
 
         public PairMetadata withFee(BigInteger fee) {
@@ -804,13 +1152,20 @@ public class DexPriceService {
                 return this;
             }
             return new PairMetadata(pairAddress, token0, token1, token0Decimals, token1Decimals,
-                    token0Symbol, token1Symbol, poolType, fee);
+                    token0Symbol, token1Symbol, poolType, fee, factoryAddress, swapName);
         }
 
         public String getDisplayName() {
             String symbol0 = token0Symbol != null ? token0Symbol : token0;
             String symbol1 = token1Symbol != null ? token1Symbol : token1;
             return symbol0.toLowerCase(java.util.Locale.ROOT) + "-" + symbol1.toLowerCase(java.util.Locale.ROOT);
+        }
+
+        public String getSwapName() {
+            if (swapName != null && !swapName.isBlank()) {
+                return swapName;
+            }
+            return factoryAddress != null ? factoryAddress : "unknown";
         }
     }
 }

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -1162,7 +1162,7 @@ public class DexPriceService {
         }
 
         public String getSwapName() {
-            if (swapName != null && !swapName.isBlank()) {
+            if (swapName != null && !StringUtils.isEmpty(swapName)) {
                 return swapName;
             }
             return factoryAddress != null ? factoryAddress : "unknown";

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -347,8 +347,6 @@ public class LiquidityMonitorService {
             V4PoolMetadata previous = v4Pools.putIfAbsent(normalizedPoolId, metadata);
             if (previous == null) {
                 Instant timestamp = resolveLogTimestamp(logEntry);
-                String currency0Display = formatCurrencyDisplay(metadata.currency0Symbol, currency0);
-                String currency1Display = formatCurrencyDisplay(metadata.currency1Symbol, currency1);
                 BigInteger currency0Decimals = priceService.resolveTokenDecimals(currency0);
                 BigInteger currency1Decimals = priceService.resolveTokenDecimals(currency1);
                 Optional<BigDecimal> rawPriceOpt = calculateToken1PerToken0Price(sqrtPriceX96, currency0Decimals, currency1Decimals);
@@ -360,14 +358,11 @@ public class LiquidityMonitorService {
                         .map(this::formatDecimal)
                         .orElse("unknown");
                 String trackedPriceText = trackedPriceOpt.map(this::formatDecimal).orElse("unknown");
-                log.info("POOL_INITIALIZED_V4 manager={} poolId={} name={} currency0={} currency1={} fee={} hooks={} parameters={} sqrtPriceX96={} tick={} priceToken1PerToken0={} priceToken0PerToken1={} targetTokenPrice={} time={}",
+                log.info("POOL_INITIALIZED_V4 manager={} poolId={} name={}  fee={}  parameters={} sqrtPriceX96={} tick={} priceToken1PerToken0={} priceToken0PerToken1={} targetTokenPrice={} time={}",
                         factoryAddress,
                         normalizedPoolId,
                         metadata.getDisplayName(),
-                        currency0Display,
-                        currency1Display,
                         formatFee(fee),
-                        hooks,
                         org.web3j.utils.Numeric.toHexString(parameters),
                         sqrtPriceX96,
                         tick,
@@ -439,8 +434,6 @@ public class LiquidityMonitorService {
             int sign = liquidityDelta.signum();
             String action = sign > 0 ? "POOL_ADDED_V4" : (sign < 0 ? "POOL_REMOVED_V4" : "POOL_UPDATED_V4");
             Instant timestamp = resolveLogTimestamp(logEntry);
-            String currency0Display = formatCurrencyDisplay(metadata.currency0Symbol, metadata.currency0);
-            String currency1Display = formatCurrencyDisplay(metadata.currency1Symbol, metadata.currency1);
             BigInteger decimals0 = priceService.resolveTokenDecimals(metadata.currency0);
             BigInteger decimals1 = priceService.resolveTokenDecimals(metadata.currency1);
             Optional<DexPriceService.PriceRange> priceRangeOpt = calculateV4PriceRange(metadata, decimals0, decimals1, tickLower, tickUpper);
@@ -455,16 +448,13 @@ public class LiquidityMonitorService {
                             .divide(BigDecimal.valueOf(2), 18, RoundingMode.HALF_UP))
                     .map(this::formatDecimal)
                     .orElse("unknown");
-            log.info("{} manager={} poolId={} name={} sender={} currency0={} currency1={} fee={} hooks={} tickLower={} tickUpper={} liquidityDelta={} amount0Delta={} amount1Delta={} priceRange={} avgPrice={} salt={} time={}",
+            log.info("{} manager={} poolId={} name={} sender={}  fee={}  tickLower={} tickUpper={} liquidityDelta={} amount0Delta={} amount1Delta={} priceRange={} avgPrice={} salt={} time={}",
                     action,
                     metadata.manager,
                     metadata.poolId,
                     metadata.getDisplayName(),
                     sender,
-                    currency0Display,
-                    currency1Display,
                     formatFee(metadata.fee),
-                    metadata.hooks,
                     tickLower,
                     tickUpper,
                     liquidityDelta,
@@ -953,15 +943,19 @@ public class LiquidityMonitorService {
     private String formatCurrencyDisplay(String symbol, String address) {
         String normalized = normalizeAddress(address);
         if (normalized == null) {
-            return (symbol != null && !symbol.isBlank()) ? symbol : "unknown";
+            return (symbol != null && !isBlank(symbol)) ? symbol : "unknown";
         }
         if (isZeroAddress(normalized)) {
             return "BNB(" + normalized + ")";
         }
-        if (symbol != null && !symbol.isBlank()) {
+        if (symbol != null && !isBlank(symbol)) {
             return symbol + "(" + normalized + ")";
         }
         return normalized;
+    }
+
+    private boolean isBlank(String str){
+        return str == null || str.trim().isEmpty();
     }
 
     /**

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -27,6 +27,7 @@ import org.web3j.protocol.core.methods.response.EthLog;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.MathContext;
 import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.Arrays;
@@ -68,6 +69,8 @@ public class LiquidityMonitorService {
     private final BigInteger tokenCreationBlock;
     /** 日志查询单次最大区块跨度 */
     private static final BigInteger MAX_LOG_BLOCK_RANGE = BigInteger.valueOf(50_000L);
+    /** 价格计算精度 */
+    private static final MathContext PRICE_CONTEXT = new MathContext(40, RoundingMode.HALF_UP);
 
     /** V2 PairCreated 事件 */
     private static final Event PAIR_CREATED_EVENT = new Event("PairCreated",
@@ -346,7 +349,18 @@ public class LiquidityMonitorService {
                 Instant timestamp = resolveLogTimestamp(logEntry);
                 String currency0Display = formatCurrencyDisplay(metadata.currency0Symbol, currency0);
                 String currency1Display = formatCurrencyDisplay(metadata.currency1Symbol, currency1);
-                log.info("POOL_INITIALIZED_V4 manager={} poolId={} name={} currency0={} currency1={} fee={} hooks={} parameters={} sqrtPriceX96={} tick={} time={}",
+                BigInteger currency0Decimals = priceService.resolveTokenDecimals(currency0);
+                BigInteger currency1Decimals = priceService.resolveTokenDecimals(currency1);
+                Optional<BigDecimal> rawPriceOpt = calculateToken1PerToken0Price(sqrtPriceX96, currency0Decimals, currency1Decimals);
+                Optional<BigDecimal> trackedPriceOpt = calculateTargetPriceFromSqrt(sqrtPriceX96, currency0Decimals, currency1Decimals, currency0, currency1);
+                String rawPriceText = rawPriceOpt.map(this::formatDecimal).orElse("unknown");
+                String inversePriceText = rawPriceOpt
+                        .filter(price -> price.compareTo(BigDecimal.ZERO) > 0)
+                        .map(price -> BigDecimal.ONE.divide(price, 18, RoundingMode.HALF_UP))
+                        .map(this::formatDecimal)
+                        .orElse("unknown");
+                String trackedPriceText = trackedPriceOpt.map(this::formatDecimal).orElse("unknown");
+                log.info("POOL_INITIALIZED_V4 manager={} poolId={} name={} currency0={} currency1={} fee={} hooks={} parameters={} sqrtPriceX96={} tick={} priceToken1PerToken0={} priceToken0PerToken1={} targetTokenPrice={} time={}",
                         factoryAddress,
                         normalizedPoolId,
                         metadata.getDisplayName(),
@@ -357,6 +371,9 @@ public class LiquidityMonitorService {
                         org.web3j.utils.Numeric.toHexString(parameters),
                         sqrtPriceX96,
                         tick,
+                        rawPriceText,
+                        inversePriceText,
+                        trackedPriceText,
                         timestamp);
             }
             subscribeV4ModifyLiquidity(factoryAddress, poolIdTopic);
@@ -424,7 +441,21 @@ public class LiquidityMonitorService {
             Instant timestamp = resolveLogTimestamp(logEntry);
             String currency0Display = formatCurrencyDisplay(metadata.currency0Symbol, metadata.currency0);
             String currency1Display = formatCurrencyDisplay(metadata.currency1Symbol, metadata.currency1);
-            log.info("{} manager={} poolId={} name={} sender={} currency0={} currency1={} fee={} hooks={} tickLower={} tickUpper={} liquidityDelta={} salt={} time={}",
+            BigInteger decimals0 = priceService.resolveTokenDecimals(metadata.currency0);
+            BigInteger decimals1 = priceService.resolveTokenDecimals(metadata.currency1);
+            Optional<DexPriceService.PriceRange> priceRangeOpt = calculateV4PriceRange(metadata, decimals0, decimals1, tickLower, tickUpper);
+            String priceRangeText = formatPriceRange(priceRangeOpt);
+            Optional<LiquidityEstimation> estimationOpt = estimateV4LiquidityDelta(liquidityDelta, tickLower, tickUpper, decimals0, decimals1);
+            BigDecimal amount0Signed = estimationOpt.map(est -> applySign(est.amount0, sign)).orElse(null);
+            BigDecimal amount1Signed = estimationOpt.map(est -> applySign(est.amount1, sign)).orElse(null);
+            String amount0Text = amount0Signed != null ? formatDecimal(amount0Signed) : "unknown";
+            String amount1Text = amount1Signed != null ? formatDecimal(amount1Signed) : "unknown";
+            String averagePriceText = priceRangeOpt
+                    .map(range -> range.lower.add(range.upper, PRICE_CONTEXT)
+                            .divide(BigDecimal.valueOf(2), 18, RoundingMode.HALF_UP))
+                    .map(this::formatDecimal)
+                    .orElse("unknown");
+            log.info("{} manager={} poolId={} name={} sender={} currency0={} currency1={} fee={} hooks={} tickLower={} tickUpper={} liquidityDelta={} amount0Delta={} amount1Delta={} priceRange={} avgPrice={} salt={} time={}",
                     action,
                     metadata.manager,
                     metadata.poolId,
@@ -437,6 +468,10 @@ public class LiquidityMonitorService {
                     tickLower,
                     tickUpper,
                     liquidityDelta,
+                    amount0Text,
+                    amount1Text,
+                    priceRangeText,
+                    averagePriceText,
                     salt,
                     timestamp);
         } catch (Exception ex) {
@@ -649,15 +684,45 @@ public class LiquidityMonitorService {
         String normalized = metadata.pairAddress.toLowerCase();
         if (registeredPools.add(normalized)) {
             transferMonitorService.addLiquidityPair(metadata.pairAddress);
+            Optional<DexPriceService.PoolSnapshot> snapshotOpt = priceService.loadPoolSnapshot(metadata);
+            String amount0Text = snapshotOpt.map(snapshot -> snapshot.token0Amount)
+                    .map(this::formatDecimal)
+                    .orElse("unknown");
+            String amount1Text = snapshotOpt.map(snapshot -> snapshot.token1Amount)
+                    .map(this::formatDecimal)
+                    .orElse("unknown");
+            String priceText = snapshotOpt
+                    .flatMap(snapshot -> snapshot.priceForToken(tokenAddress, metadata))
+                    .map(this::formatDecimal)
+                    .orElse("unknown");
+            String swapName = metadata.getSwapName();
             if (metadata.poolType == DexPriceService.PoolType.V3) {
-                log.info("POOL_REGISTERED pair={} name={} fee={}",
+                Optional<DexPriceService.PriceRange> priceRangeOpt = snapshotOpt
+                        .filter(snapshot -> snapshot.currentTick != null && snapshot.tickSpacing != null)
+                        .map(snapshot -> priceService.calculateTargetPriceRange(metadata,
+                                snapshot.currentTick - snapshot.tickSpacing,
+                                snapshot.currentTick + snapshot.tickSpacing))
+                        .orElse(Optional.empty());
+                String priceRangeText = formatPriceRange(priceRangeOpt);
+                log.info("POOL_REGISTERED pair={} swap={} name={} fee={} amount0={} amount1={} price={} priceRange={} tick={} tickSpacing={}",
                         metadata.pairAddress,
+                        swapName,
                         metadata.getDisplayName(),
-                        formatFee(metadata.fee));
+                        formatFee(metadata.fee),
+                        amount0Text,
+                        amount1Text,
+                        priceText,
+                        priceRangeText,
+                        snapshotOpt.map(snapshot -> snapshot.currentTick).map(String::valueOf).orElse("unknown"),
+                        snapshotOpt.map(snapshot -> snapshot.tickSpacing).map(String::valueOf).orElse("unknown"));
             } else {
-                log.info("POOL_REGISTERED pair={} name={}",
+                log.info("POOL_REGISTERED pair={} swap={} name={} amount0={} amount1={} price={}",
                         metadata.pairAddress,
-                        metadata.getDisplayName());
+                        swapName,
+                        metadata.getDisplayName(),
+                        amount0Text,
+                        amount1Text,
+                        priceText);
             }
         }
     }
@@ -897,6 +962,231 @@ public class LiquidityMonitorService {
             return symbol + "(" + normalized + ")";
         }
         return normalized;
+    }
+
+    /**
+     * 计算 V4 价格区间
+     *
+     * @param metadata  池子元数据
+     * @param decimals0 货币 0 精度
+     * @param decimals1 货币 1 精度
+     * @param tickLower 下界 tick
+     * @param tickUpper 上界 tick
+     * @return 价格区间
+     */
+    private Optional<DexPriceService.PriceRange> calculateV4PriceRange(V4PoolMetadata metadata,
+                                                                       BigInteger decimals0,
+                                                                       BigInteger decimals1,
+                                                                       int tickLower,
+                                                                       int tickUpper) {
+        if (metadata == null) {
+            return Optional.empty();
+        }
+        String swapName = Optional.ofNullable(metadata.manager)
+                .map(address -> DexConstants.FACTORY_NAMES.getOrDefault(address.toLowerCase(Locale.ROOT), address))
+                .orElse("unknown");
+        DexPriceService.PairMetadata pseudo = new DexPriceService.PairMetadata(
+                metadata.poolId,
+                metadata.currency0,
+                metadata.currency1,
+                decimals0,
+                decimals1,
+                metadata.currency0Symbol,
+                metadata.currency1Symbol,
+                DexPriceService.PoolType.V3,
+                metadata.fee,
+                metadata.manager,
+                swapName);
+        return priceService.calculateTargetPriceRange(pseudo, tickLower, tickUpper);
+    }
+
+    /**
+     * 估算 V4 流动性变化对应的代币数量
+     *
+     * @param liquidityDelta 流动性变化量
+     * @param tickLower      下界 tick
+     * @param tickUpper      上界 tick
+     * @param decimals0      货币 0 精度
+     * @param decimals1      货币 1 精度
+     * @return 估算结果
+     */
+    private Optional<LiquidityEstimation> estimateV4LiquidityDelta(BigInteger liquidityDelta,
+                                                                   int tickLower,
+                                                                   int tickUpper,
+                                                                   BigInteger decimals0,
+                                                                   BigInteger decimals1) {
+        if (liquidityDelta == null || liquidityDelta.equals(BigInteger.ZERO)) {
+            return Optional.empty();
+        }
+        BigDecimal sqrtLower = sqrtRatioAtTick(tickLower);
+        BigDecimal sqrtUpper = sqrtRatioAtTick(tickUpper);
+        if (sqrtLower == null || sqrtUpper == null
+                || sqrtLower.compareTo(BigDecimal.ZERO) <= 0
+                || sqrtUpper.compareTo(BigDecimal.ZERO) <= 0) {
+            return Optional.empty();
+        }
+        BigDecimal sqrtCurrent = sqrtRatioAtTick((tickLower + tickUpper) / 2);
+        BigDecimal liquidity = new BigDecimal(liquidityDelta.abs());
+        BigDecimal amount0Raw;
+        BigDecimal amount1Raw;
+        if (sqrtCurrent.compareTo(sqrtLower) <= 0) {
+            BigDecimal numerator = liquidity.multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
+            BigDecimal denominator = sqrtUpper.multiply(sqrtLower, PRICE_CONTEXT);
+            amount0Raw = numerator.divide(denominator, 18, RoundingMode.HALF_UP);
+            amount1Raw = BigDecimal.ZERO;
+        } else if (sqrtCurrent.compareTo(sqrtUpper) >= 0) {
+            amount0Raw = BigDecimal.ZERO;
+            amount1Raw = liquidity.multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
+        } else {
+            BigDecimal numerator0 = liquidity.multiply(sqrtUpper.subtract(sqrtCurrent, PRICE_CONTEXT), PRICE_CONTEXT);
+            BigDecimal denominator0 = sqrtCurrent.multiply(sqrtUpper, PRICE_CONTEXT);
+            amount0Raw = numerator0.divide(denominator0, 18, RoundingMode.HALF_UP);
+            amount1Raw = liquidity.multiply(sqrtCurrent.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
+        }
+        BigDecimal normalized0 = normalizeTokenAmount(amount0Raw, decimals0);
+        BigDecimal normalized1 = normalizeTokenAmount(amount1Raw, decimals1);
+        return Optional.of(new LiquidityEstimation(normalized0, normalized1));
+    }
+
+    /**
+     * 归一化代币数量
+     *
+     * @param amount   原始数量
+     * @param decimals 精度
+     * @return 标准化数量
+     */
+    private BigDecimal normalizeTokenAmount(BigDecimal amount, BigInteger decimals) {
+        if (amount == null) {
+            return null;
+        }
+        int scale = decimals != null ? decimals.intValue() : 18;
+        if (scale < 0) {
+            scale = 0;
+        }
+        BigDecimal divisor = BigDecimal.TEN.pow(scale);
+        if (divisor.compareTo(BigDecimal.ZERO) == 0) {
+            return null;
+        }
+        return amount.divide(divisor, 18, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * 为数值应用符号
+     *
+     * @param amount 数值
+     * @param sign   符号
+     * @return 带符号的数值
+     */
+    private BigDecimal applySign(BigDecimal amount, int sign) {
+        if (amount == null) {
+            return null;
+        }
+        if (sign == 0) {
+            return BigDecimal.ZERO;
+        }
+        return amount.multiply(BigDecimal.valueOf(sign));
+    }
+
+    /**
+     * 根据 sqrtPriceX96 计算 token1/token0 价格
+     *
+     * @param sqrtPriceX96 sqrtPrice 值
+     * @param decimals0    货币 0 精度
+     * @param decimals1    货币 1 精度
+     * @return 价格
+     */
+    private Optional<BigDecimal> calculateToken1PerToken0Price(BigInteger sqrtPriceX96,
+                                                               BigInteger decimals0,
+                                                               BigInteger decimals1) {
+        if (sqrtPriceX96 == null || sqrtPriceX96.equals(BigInteger.ZERO)) {
+            return Optional.empty();
+        }
+        BigDecimal sqrtPrice = new BigDecimal(sqrtPriceX96);
+        BigDecimal numerator = sqrtPrice.multiply(sqrtPrice, PRICE_CONTEXT);
+        BigDecimal denominator = new BigDecimal(BigInteger.ONE.shiftLeft(192));
+        BigDecimal ratio = numerator.divide(denominator, 18, RoundingMode.HALF_UP);
+        return Optional.of(adjustForDecimals(ratio, decimals0, decimals1));
+    }
+
+    /**
+     * 计算目标代币价格
+     *
+     * @param sqrtPriceX96 sqrtPrice 值
+     * @param decimals0    货币 0 精度
+     * @param decimals1    货币 1 精度
+     * @param currency0    货币 0 地址
+     * @param currency1    货币 1 地址
+     * @return 目标代币价格
+     */
+    private Optional<BigDecimal> calculateTargetPriceFromSqrt(BigInteger sqrtPriceX96,
+                                                              BigInteger decimals0,
+                                                              BigInteger decimals1,
+                                                              String currency0,
+                                                              String currency1) {
+        Optional<BigDecimal> rawPriceOpt = calculateToken1PerToken0Price(sqrtPriceX96, decimals0, decimals1);
+        if (!rawPriceOpt.isPresent()) {
+            return Optional.empty();
+        }
+        BigDecimal rawPrice = rawPriceOpt.get();
+        if (currency0 != null && currency0.equalsIgnoreCase(tokenAddress)) {
+            return Optional.of(rawPrice);
+        }
+        if (currency1 != null && currency1.equalsIgnoreCase(tokenAddress) && rawPrice.compareTo(BigDecimal.ZERO) > 0) {
+            return Optional.of(BigDecimal.ONE.divide(rawPrice, 18, RoundingMode.HALF_UP));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * 根据精度调整价格
+     *
+     * @param price     原始价格
+     * @param decimals0 货币 0 精度
+     * @param decimals1 货币 1 精度
+     * @return 调整后的价格
+     */
+    private BigDecimal adjustForDecimals(BigDecimal price, BigInteger decimals0, BigInteger decimals1) {
+        if (price == null) {
+            return null;
+        }
+        int scale0 = decimals0 != null ? decimals0.intValue() : 18;
+        int scale1 = decimals1 != null ? decimals1.intValue() : 18;
+        int diff = scale0 - scale1;
+        if (diff == 0) {
+            return price;
+        }
+        BigDecimal factor = BigDecimal.TEN.pow(Math.abs(diff));
+        if (diff > 0) {
+            return price.multiply(factor, PRICE_CONTEXT);
+        }
+        return price.divide(factor, PRICE_CONTEXT);
+    }
+
+    /**
+     * 根据 tick 计算对应的 sqrt 价格
+     *
+     * @param tick tick 值
+     * @return sqrt 价格
+     */
+    private BigDecimal sqrtRatioAtTick(int tick) {
+        double exponent = tick / 2.0d;
+        double value = Math.pow(1.0001d, exponent);
+        return new BigDecimal(Double.toString(value), PRICE_CONTEXT);
+    }
+
+    /**
+     * 流动性估算结果
+     */
+    private static class LiquidityEstimation {
+        /** 货币 0 数量 */
+        private final BigDecimal amount0;
+        /** 货币 1 数量 */
+        private final BigDecimal amount1;
+
+        private LiquidityEstimation(BigDecimal amount0, BigDecimal amount1) {
+            this.amount0 = amount0;
+            this.amount1 = amount1;
+        }
     }
 
     /**

--- a/src/main/java/com/example/monitor/StringUtils.java
+++ b/src/main/java/com/example/monitor/StringUtils.java
@@ -1,0 +1,8 @@
+package com.example.monitor;
+
+public class StringUtils {
+
+    public static boolean isEmpty(String str) {
+        return str == null || str.trim().isEmpty();
+    }
+}

--- a/src/main/java/com/example/monitor/TokenInfoService.java
+++ b/src/main/java/com/example/monitor/TokenInfoService.java
@@ -5,10 +5,12 @@ import org.slf4j.LoggerFactory;
 import org.web3j.abi.FunctionEncoder;
 import org.web3j.abi.FunctionReturnDecoder;
 import org.web3j.abi.TypeReference;
+import org.web3j.abi.datatypes.Address;
 import org.web3j.abi.datatypes.Function;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.Utf8String;
 import org.web3j.abi.datatypes.generated.Uint8;
+import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
@@ -76,6 +78,28 @@ public class TokenInfoService {
         return callSingleValueReturn(tokenAddress, function)
                 .map(value -> (Utf8String) value)
                 .map(Utf8String::getValue);
+    }
+
+    /**
+     * 查询指定地址的代币余额
+     *
+     * @param tokenAddress 代币合约地址
+     * @param ownerAddress 地址
+     * @return 余额
+     */
+    public Optional<BigInteger> loadBalance(String tokenAddress, String ownerAddress) {
+        if (tokenAddress == null || ownerAddress == null) {
+            return Optional.empty();
+        }
+        Function function = new Function(
+                "balanceOf",
+                Collections.singletonList(new Address(ownerAddress)),
+                Collections.singletonList(new TypeReference<Uint256>() {
+                })
+        );
+        return callSingleValueReturn(tokenAddress, function)
+                .map(value -> (Uint256) value)
+                .map(Uint256::getValue);
     }
 
     /**

--- a/src/main/java/com/example/monitor/TransferAggregator.java
+++ b/src/main/java/com/example/monitor/TransferAggregator.java
@@ -110,24 +110,49 @@ public class TransferAggregator {
      * 转账记录结构体
      */
     public static class TransferRecord {
+        /** 时间戳 */
         private final long timestamp;
+        /** 美元价值 */
         private final BigDecimal usdValue;
+        /** 成交方向 */
         private final Direction direction;
 
+        /**
+         * 构造函数
+         *
+         * @param timestamp 时间戳
+         * @param usdValue  美元价值
+         * @param direction 成交方向
+         */
         public TransferRecord(long timestamp, BigDecimal usdValue, Direction direction) {
             this.timestamp = timestamp;
             this.usdValue = usdValue;
             this.direction = direction;
         }
 
+        /**
+         * 获取时间戳
+         *
+         * @return 时间戳
+         */
         public long getTimestamp() {
             return timestamp;
         }
 
+        /**
+         * 获取美元价值
+         *
+         * @return 美元价值
+         */
         public BigDecimal getUsdValue() {
             return usdValue;
         }
 
+        /**
+         * 获取成交方向
+         *
+         * @return 成交方向
+         */
         public Direction getDirection() {
             return direction;
         }


### PR DESCRIPTION
## Summary
- add swap name, reserve balances, and current pricing to pool registration logs with supporting snapshot helpers
- enrich V4 initialize and modify liquidity handlers with initial pricing, estimated token deltas, and other analytics
- document previously undocumented members and expose token balance queries to support liquidity reporting

## Testing
- `mvn -q -DskipTests package` *(fails: Maven central returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e2286559148326a7442741c7456aaf