### PR TITLE
Fix DEX cache handling and log TVL for pools

### DIFF
--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -31,6 +31,8 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -59,12 +61,12 @@ public class DexPriceService {
     private final Map<String, BigInteger> decimalsCache = new ConcurrentHashMap<>();
     /** 代币符号缓存 */
     private final Map<String, String> symbolCache = new ConcurrentHashMap<>();
-    /** 按 token 组合缓存的 V2 配对信息 */
-    private final Map<String, List<PairMetadata>> pairCacheByTokens = new ConcurrentHashMap<>();
+    /** 按 token 组合缓存的 V2 配对信息（按池子地址去重） */
+    private final Map<String, Map<String, PairMetadata>> pairCacheByTokens = new ConcurrentHashMap<>();
     /** 按地址缓存的池子信息 */
     private final Map<String, PairMetadata> pairCacheByAddress = new ConcurrentHashMap<>();
-    /** 按 token 与费率缓存的 V3 池子信息 */
-    private final Map<String, PairMetadata> v3PoolCache = new ConcurrentHashMap<>();
+    /** 按 token、顺序与费率缓存的 V3 池子信息 */
+    private final Map<String, Map<String, PairMetadata>> v3PoolCache = new ConcurrentHashMap<>();
 
     /** 价格计算精度 */
     private static final MathContext PRICE_MATH_CONTEXT = new MathContext(40, RoundingMode.HALF_UP);
@@ -430,12 +432,12 @@ public class DexPriceService {
      */
     public List<PairMetadata> findOrCreatePairs(String tokenA, String tokenB) {
         String key = buildPairKey(tokenA, tokenB);
-        List<PairMetadata> cached = pairCacheByTokens.get(key);
+        Map<String, PairMetadata> cachedByAddress = pairCacheByTokens.get(key);
         List<PairMetadata> result = new ArrayList<>();
-        Set<String> seenAddresses = ConcurrentHashMap.newKeySet();
-        if (cached != null) {
-            result.addAll(cached);
-            cached.stream().map(meta -> normalize(meta.pairAddress)).forEach(seenAddresses::add);
+        Set<String> seenAddresses = new HashSet<>();
+        if (cachedByAddress != null) {
+            result.addAll(cachedByAddress.values());
+            seenAddresses.addAll(cachedByAddress.keySet());
         }
         for (String factory : DexConstants.V2_FACTORIES) {
             Optional<PairMetadata> metadata = queryPair(factory, tokenA, tokenB);
@@ -444,8 +446,8 @@ public class DexPriceService {
                 String normalizedAddress = normalize(pair.pairAddress);
                 if (seenAddresses.add(normalizedAddress)) {
                     result.add(pair);
-                    cachePairMetadata(pair, true);
                 }
+                cachePairMetadata(pair, true);
             }
         }
         return result;
@@ -462,20 +464,23 @@ public class DexPriceService {
         List<PairMetadata> pools = new ArrayList<>();
         for (BigInteger fee : DexConstants.V3_FEE_TIERS) {
             String key = buildV3PoolKey(tokenA, tokenB, fee);
-            PairMetadata cached = v3PoolCache.get(key);
-            if (cached != null) {
-                pools.add(cached);
-                continue;
+            Map<String, PairMetadata> cachedByAddress = v3PoolCache.get(key);
+            Set<String> seenAddresses = new HashSet<>();
+            if (cachedByAddress != null) {
+                pools.addAll(cachedByAddress.values());
+                seenAddresses.addAll(cachedByAddress.keySet());
             }
             for (String factory : DexConstants.V3_FACTORIES) {
                 Optional<PairMetadata> metadata = queryV3Pool(factory, tokenA, tokenB, fee);
-                if (metadata.isPresent()) {
-                    PairMetadata pairMetadata = metadata.get();
-                    v3PoolCache.put(key, pairMetadata);
-                    v3PoolCache.put(buildV3PoolKey(tokenB, tokenA, fee), pairMetadata);
-                    pools.add(pairMetadata);
-                    break;
+                if (!metadata.isPresent()) {
+                    continue;
                 }
+                PairMetadata pairMetadata = metadata.get();
+                String normalizedAddress = normalize(pairMetadata.pairAddress);
+                if (seenAddresses.add(normalizedAddress)) {
+                    pools.add(pairMetadata);
+                }
+                cachePairMetadata(pairMetadata, false);
             }
         }
         return pools;
@@ -629,6 +634,10 @@ public class DexPriceService {
             addPairToTokenCache(metadata.token0, metadata.token1, metadata);
             addPairToTokenCache(metadata.token1, metadata.token0, metadata);
         }
+        if (metadata.poolType == PoolType.V3 && metadata.fee != null) {
+            addV3PoolToCache(metadata.token0, metadata.token1, metadata.fee, metadata);
+            addV3PoolToCache(metadata.token1, metadata.token0, metadata.fee, metadata);
+        }
     }
 
     /**
@@ -640,20 +649,31 @@ public class DexPriceService {
      */
     private void addPairToTokenCache(String tokenA, String tokenB, PairMetadata metadata) {
         String key = buildPairKey(tokenA, tokenB);
-        pairCacheByTokens.compute(key, (k, list) -> {
-            List<PairMetadata> updated = list == null ? new ArrayList<>() : new ArrayList<>(list);
-            boolean replaced = false;
+        pairCacheByTokens.compute(key, (k, existing) -> {
+            Map<String, PairMetadata> updated = existing == null ? new LinkedHashMap<>() : new LinkedHashMap<>(existing);
             String normalizedAddress = normalize(metadata.pairAddress);
-            for (int i = 0; i < updated.size(); i++) {
-                if (normalize(updated.get(i).pairAddress).equals(normalizedAddress)) {
-                    updated.set(i, metadata);
-                    replaced = true;
-                    break;
-                }
-            }
-            if (!replaced) {
-                updated.add(metadata);
-            }
+            updated.put(normalizedAddress, metadata);
+            return updated;
+        });
+    }
+
+    /**
+     * 将 V3 池子加入缓存
+     *
+     * @param tokenA    代币 A
+     * @param tokenB    代币 B
+     * @param fee       费率
+     * @param metadata  池子信息
+     */
+    private void addV3PoolToCache(String tokenA, String tokenB, BigInteger fee, PairMetadata metadata) {
+        if (fee == null) {
+            return;
+        }
+        String key = buildV3PoolKey(tokenA, tokenB, fee);
+        v3PoolCache.compute(key, (k, existing) -> {
+            Map<String, PairMetadata> updated = existing == null ? new LinkedHashMap<>() : new LinkedHashMap<>(existing);
+            String normalizedAddress = normalize(metadata.pairAddress);
+            updated.put(normalizedAddress, metadata);
             return updated;
         });
     }

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -671,6 +671,7 @@ public class LiquidityMonitorService {
                     .flatMap(snapshot -> snapshot.priceForToken(tokenAddress, metadata))
                     .map(this::formatDecimal)
                     .orElse("unknown");
+            String tvlText = formatTvl(snapshotOpt.flatMap(snapshot -> calculateTvl(metadata, snapshot)));
             String swapName = metadata.getSwapName();
             if (metadata.poolType == DexPriceService.PoolType.V3) {
                 Optional<DexPriceService.PriceRange> priceRangeOpt = snapshotOpt
@@ -680,7 +681,7 @@ public class LiquidityMonitorService {
                                 snapshot.currentTick + snapshot.tickSpacing))
                         .orElse(Optional.empty());
                 String priceRangeText = formatPriceRange(priceRangeOpt);
-                log.info("POOL_REGISTERED pair={} swap={} name={} fee={} amount0={} amount1={} price={} priceRange={} tick={} tickSpacing={}",
+                log.info("POOL_REGISTERED pair={} swap={} name={} fee={} amount0={} amount1={} price={} priceRange={} tick={} tickSpacing={} tvl={}",
                         metadata.pairAddress,
                         swapName,
                         metadata.getDisplayName(),
@@ -690,15 +691,17 @@ public class LiquidityMonitorService {
                         priceText,
                         priceRangeText,
                         snapshotOpt.map(snapshot -> snapshot.currentTick).map(String::valueOf).orElse("unknown"),
-                        snapshotOpt.map(snapshot -> snapshot.tickSpacing).map(String::valueOf).orElse("unknown"));
+                        snapshotOpt.map(snapshot -> snapshot.tickSpacing).map(String::valueOf).orElse("unknown"),
+                        tvlText);
             } else {
-                log.info("POOL_REGISTERED pair={} swap={} name={} amount0={} amount1={} price={}",
+                log.info("POOL_REGISTERED pair={} swap={} name={} amount0={} amount1={} price={} tvl={}",
                         metadata.pairAddress,
                         swapName,
                         metadata.getDisplayName(),
                         amount0Text,
                         amount1Text,
-                        priceText);
+                        priceText,
+                        tvlText);
             }
         }
     }
@@ -1259,6 +1262,87 @@ public class LiquidityMonitorService {
         return rangeOpt
                 .map(range -> String.format("[%s, %s]", formatDecimal(range.lower), formatDecimal(range.upper)))
                 .orElse("[]");
+    }
+
+    /**
+     * 计算并格式化 TVL 文本
+     */
+    private String formatTvl(Optional<TvlInfo> tvlOpt) {
+        return tvlOpt
+                .map(tvl -> {
+                    String amount = formatDecimal(tvl.amount);
+                    if (tvl.symbol == null || tvl.symbol.isEmpty()) {
+                        return amount;
+                    }
+                    return amount + " " + tvl.symbol;
+                })
+                .orElse("unknown");
+    }
+
+    /**
+     * 计算池子的 TVL
+     */
+    private Optional<TvlInfo> calculateTvl(DexPriceService.PairMetadata metadata, DexPriceService.PoolSnapshot snapshot) {
+        if (metadata == null || snapshot == null) {
+            return Optional.empty();
+        }
+        BigDecimal amount0 = snapshot.token0Amount;
+        BigDecimal amount1 = snapshot.token1Amount;
+        if (amount0 == null || amount1 == null) {
+            return Optional.empty();
+        }
+        BigDecimal ratio = snapshot.priceToken1PerToken0;
+        if (ratio == null || ratio.compareTo(BigDecimal.ZERO) <= 0) {
+            return Optional.empty();
+        }
+
+        BigDecimal tvlAmount;
+        String symbol;
+        if (metadata.token1.equalsIgnoreCase(DexConstants.USDT_ADDRESS)) {
+            symbol = resolveSymbol(metadata.token1Symbol, metadata.token1);
+            tvlAmount = amount1.add(amount0.multiply(ratio, PRICE_CONTEXT));
+        } else if (metadata.token0.equalsIgnoreCase(DexConstants.USDT_ADDRESS)) {
+            symbol = resolveSymbol(metadata.token0Symbol, metadata.token0);
+            tvlAmount = amount0.add(amount1.divide(ratio, 18, RoundingMode.HALF_UP));
+        } else if (metadata.token0.equalsIgnoreCase(tokenAddress)) {
+            symbol = resolveSymbol(metadata.token1Symbol, metadata.token1);
+            tvlAmount = amount1.add(amount0.multiply(ratio, PRICE_CONTEXT));
+        } else if (metadata.token1.equalsIgnoreCase(tokenAddress)) {
+            symbol = resolveSymbol(metadata.token0Symbol, metadata.token0);
+            Optional<BigDecimal> priceOpt = snapshot.priceForToken(tokenAddress, metadata);
+            if (!priceOpt.isPresent() || priceOpt.get().compareTo(BigDecimal.ZERO) <= 0) {
+                return Optional.empty();
+            }
+            tvlAmount = amount0.add(amount1.multiply(priceOpt.get(), PRICE_CONTEXT));
+        } else {
+            symbol = resolveSymbol(metadata.token1Symbol, metadata.token1);
+            tvlAmount = amount1.add(amount0.multiply(ratio, PRICE_CONTEXT));
+        }
+
+        return Optional.of(new TvlInfo(tvlAmount.setScale(18, RoundingMode.HALF_UP), symbol));
+    }
+
+    /**
+     * 解析符号
+     */
+    private String resolveSymbol(String symbol, String fallback) {
+        if (symbol != null && !symbol.isEmpty()) {
+            return symbol;
+        }
+        return fallback == null ? "" : fallback;
+    }
+
+    /**
+     * TVL 信息
+     */
+    private static class TvlInfo {
+        private final BigDecimal amount;
+        private final String symbol;
+
+        private TvlInfo(BigDecimal amount, String symbol) {
+            this.amount = amount;
+            this.symbol = symbol;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- refactor DEX pair and pool caches to keep entries per pool address so PancakeSwap and Uniswap metadata do not overwrite each other
- update V3 pool discovery to collect pools from every factory while reusing the enriched cache entries
- log TVL values alongside amount and price details when registering V2/V3 pools

## Testing
- `mvn -q -DskipTests compile` *(fails: Maven Central 403 while downloading plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68e2427cb02c83269b8594ac3a22a474