### PR TITLE
Ignore liquidity adjustments when aggregating transfers

### DIFF
--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -133,8 +133,8 @@ public class LiquidityMonitorService {
                     TypeReference.create(Uint256.class),
                     TypeReference.create(Uint256.class)
             ));
-    /** V4 Initialize 事件 */
-    private static final Event INITIALIZE_EVENT_V4 = new Event("Initialize",
+    /** PancakeSwap V4 Initialize 事件 */
+    private static final Event INITIALIZE_EVENT_V4_PANCAKE = new Event("Initialize",
             Arrays.asList(
                     TypeReference.create(Bytes32.class, true),
                     TypeReference.create(Address.class),
@@ -144,6 +144,18 @@ public class LiquidityMonitorService {
                     TypeReference.create(Uint160.class),
                     TypeReference.create(Uint24.class),
                     TypeReference.create(Address.class)
+            ));
+    /** Uniswap V4 Initialize 事件 */
+    private static final Event INITIALIZE_EVENT_V4_UNISWAP = new Event("Initialize",
+            Arrays.asList(
+                    TypeReference.create(Bytes32.class, true),
+                    TypeReference.create(Address.class, true),
+                    TypeReference.create(Address.class, true),
+                    TypeReference.create(Uint24.class),
+                    TypeReference.create(Int24.class),
+                    TypeReference.create(Address.class),
+                    TypeReference.create(Uint160.class),
+                    TypeReference.create(Int24.class)
             ));
     /** V4 ModifyLiquidity 事件 */
     private static final Event MODIFY_LIQUIDITY_EVENT_V4 = new Event("ModifyLiquidity",
@@ -226,17 +238,29 @@ public class LiquidityMonitorService {
      * @param factoryAddress 工厂合约地址
      */
     private void subscribeV4Factory(String factoryAddress) {
+        Event initEvent = resolveV4InitializeEvent(factoryAddress);
         DefaultBlockParameter subscriptionStart = prepareHistoricalSubscription(
                 factoryAddress,
-                INITIALIZE_EVENT_V4,
+                initEvent,
                 Collections.emptyList(),
                 logEntry -> handleV4InitializeLog(factoryAddress, logEntry),
                 "V4 initialize"
         );
         EthFilter initFilter = new EthFilter(subscriptionStart, DefaultBlockParameterName.LATEST, factoryAddress);
-        initFilter.addSingleTopic(EventEncoder.encode(INITIALIZE_EVENT_V4));
+        initFilter.addSingleTopic(EventEncoder.encode(initEvent));
         web3j.ethLogFlowable(initFilter).subscribe(logEntry -> handleV4InitializeLog(factoryAddress, logEntry), throwable ->
                 log.error("Error processing V4 initialize event", throwable));
+    }
+
+    /**
+     * 根据工厂地址解析对应的 V4 Initialize 事件
+     */
+    private Event resolveV4InitializeEvent(String factoryAddress) {
+        String normalized = normalizeAddress(factoryAddress);
+        if (normalized != null && DexConstants.UNISWAP_V4_FACTORY.equalsIgnoreCase(normalized)) {
+            return INITIALIZE_EVENT_V4_UNISWAP;
+        }
+        return INITIALIZE_EVENT_V4_PANCAKE;
     }
 
     /**
@@ -358,15 +382,32 @@ public class LiquidityMonitorService {
                 return;
             }
             String poolIdTopic = topics.get(1);
-            List<Type> data = decodeEventData(logEntry.getData(), INITIALIZE_EVENT_V4);
-            if (data.size() < 7) {
-                return;
+            Event initEvent = resolveV4InitializeEvent(factoryAddress);
+            List<Type> data = decodeEventData(logEntry.getData(), initEvent);
+            String currency0;
+            String currency1;
+            BigInteger fee;
+            BigInteger sqrtPriceX96;
+            String hooks;
+            if (initEvent == INITIALIZE_EVENT_V4_UNISWAP) {
+                if (topics.size() < 4 || data.size() < 5) {
+                    return;
+                }
+                currency0 = normalizeAddress(decodeAddress(topics.get(2)));
+                currency1 = normalizeAddress(decodeAddress(topics.get(3)));
+                fee = ((Uint24) data.get(0)).getValue();
+                sqrtPriceX96 = ((Uint160) data.get(3)).getValue();
+                hooks = normalizeAddress(((Address) data.get(2)).getValue());
+            } else {
+                if (data.size() < 7) {
+                    return;
+                }
+                currency0 = normalizeAddress(((Address) data.get(0)).getValue());
+                currency1 = normalizeAddress(((Address) data.get(1)).getValue());
+                fee = ((Uint24) data.get(2)).getValue();
+                sqrtPriceX96 = ((Uint160) data.get(4)).getValue();
+                hooks = normalizeAddress(((Address) data.get(6)).getValue());
             }
-            String currency0 = normalizeAddress(((Address) data.get(0)).getValue());
-            String currency1 = normalizeAddress(((Address) data.get(1)).getValue());
-            BigInteger fee = ((Uint24) data.get(2)).getValue();
-            BigInteger sqrtPriceX96 = ((Uint160) data.get(4)).getValue();
-            String hooks = normalizeAddress(((Address) data.get(6)).getValue());
             if (!matchesTarget(currency0, currency1)) {
                 return;
             }

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -137,13 +137,13 @@ public class LiquidityMonitorService {
     private static final Event INITIALIZE_EVENT_V4_PANCAKE = new Event("Initialize",
             Arrays.asList(
                     TypeReference.create(Bytes32.class, true),
-                    TypeReference.create(Address.class),
+                    TypeReference.create(Address.class, true),
+                    TypeReference.create(Address.class, true),
                     TypeReference.create(Address.class),
                     TypeReference.create(Uint24.class),
-                    TypeReference.create(Int24.class),
+                    TypeReference.create(Bytes32.class),
                     TypeReference.create(Uint160.class),
-                    TypeReference.create(Uint24.class),
-                    TypeReference.create(Address.class)
+                    TypeReference.create(Int24.class)
             ));
     /** Uniswap V4 Initialize 事件 */
     private static final Event INITIALIZE_EVENT_V4_UNISWAP = new Event("Initialize",
@@ -399,14 +399,14 @@ public class LiquidityMonitorService {
                 sqrtPriceX96 = ((Uint160) data.get(3)).getValue();
                 hooks = normalizeAddress(((Address) data.get(2)).getValue());
             } else {
-                if (data.size() < 7) {
+                if (topics.size() < 4 || data.size() < 5) {
                     return;
                 }
-                currency0 = normalizeAddress(((Address) data.get(0)).getValue());
-                currency1 = normalizeAddress(((Address) data.get(1)).getValue());
-                fee = ((Uint24) data.get(2)).getValue();
-                sqrtPriceX96 = ((Uint160) data.get(4)).getValue();
-                hooks = normalizeAddress(((Address) data.get(6)).getValue());
+                currency0 = normalizeAddress(decodeAddress(topics.get(2)));
+                currency1 = normalizeAddress(decodeAddress(topics.get(3)));
+                hooks = normalizeAddress(((Address) data.get(0)).getValue());
+                fee = ((Uint24) data.get(1)).getValue();
+                sqrtPriceX96 = ((Uint160) data.get(3)).getValue();
             }
             if (!matchesTarget(currency0, currency1)) {
                 return;

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -379,6 +379,11 @@ public class LiquidityMonitorService {
                     hooks);
             V4PoolMetadata previous = v4Pools.putIfAbsent(normalizedPoolId, metadata);
             V4PoolMetadata effectiveMetadata = previous != null ? previous : metadata;
+            if (previous == null) {
+                if (metadata.manager != null) {
+                    transferMonitorService.addLiquidityPair(metadata.manager);
+                }
+            }
             BigInteger currency0Decimals = priceService.resolveTokenDecimals(currency0);
             BigInteger currency1Decimals = priceService.resolveTokenDecimals(currency1);
             Optional<BigDecimal> rawPriceOpt = calculateToken1PerToken0Price(sqrtPriceX96, currency0Decimals, currency1Decimals);
@@ -390,6 +395,7 @@ public class LiquidityMonitorService {
             });
             if (previous == null && state != null) {
                 String timestampText = formatTimestamp(resolveLogTimestamp(logEntry));
+                String swapName = resolveV4SwapName(effectiveMetadata);
                 String rawPriceText = rawPriceOpt.map(this::formatDecimal).orElse("unknown");
                 String inversePriceText = rawPriceOpt
                         .filter(price -> price.compareTo(BigDecimal.ZERO) > 0)
@@ -400,7 +406,8 @@ public class LiquidityMonitorService {
                 String amount0Remaining = formatAmount(state.getAmount0());
                 String amount1Remaining = formatAmount(state.getAmount1());
                 String tvlRemaining = formatTvl(calculateV4Tvl(effectiveMetadata, state));
-                log.info("POOL_INITIALIZED_V4 name={} fee={} priceToken1PerToken0={} priceToken0PerToken1={} targetTokenPrice={} amount0Remaining={} amount1Remaining={} tvlRemaining={} time={}",
+                log.info("POOL_INITIALIZED_V4 swap={} name={} fee={} priceToken1PerToken0={} priceToken0PerToken1={} targetTokenPrice={} amount0Remaining={} amount1Remaining={} tvlRemaining={} time={}",
+                        swapName,
                         effectiveMetadata.getDisplayName(),
                         formatFee(fee),
                         rawPriceText,
@@ -462,6 +469,7 @@ public class LiquidityMonitorService {
             if (metadata == null) {
                 return;
             }
+            transferMonitorService.markLiquidityAdjustmentTx(logEntry.getTransactionHash(), logEntry.getBlockNumber());
             List<Type> data = decodeEventData(logEntry.getData(), MODIFY_LIQUIDITY_EVENT_V4);
             if (data.size() < 4) {
                 return;
@@ -500,8 +508,10 @@ public class LiquidityMonitorService {
             String amount1Remaining = formatAmount(state != null ? state.getAmount1() : null);
             String tvlRemaining = formatTvl(calculateV4Tvl(metadata, state));
             String timestampText = formatTimestamp(timestamp);
-            log.info("{} name={} sender={} fee={}  amount0Delta={} amount1Delta={} priceRange={}  amount0Remaining={} amount1Remaining={} tvlRemaining={}  time={}",
+            String swapName = resolveV4SwapName(metadata);
+            log.info("{} swap={} name={} sender={} fee={}  amount0Delta={} amount1Delta={} priceRange={}  amount0Remaining={} amount1Remaining={} tvlRemaining={}  time={}",
                     action,
+                    swapName,
                     metadata.getDisplayName(),
                     sender,
                     formatFee(metadata.fee),
@@ -575,6 +585,7 @@ public class LiquidityMonitorService {
      */
     private void handleBurnLog(String pairAddress, String token0, String token1, Event event, Log logEntry) {
         try {
+            transferMonitorService.markLiquidityAdjustmentTx(logEntry.getTransactionHash(), logEntry.getBlockNumber());
             DexPriceService.PoolType poolType = event.equals(BURN_EVENT_V2)
                     ? DexPriceService.PoolType.V2
                     : DexPriceService.PoolType.V3;
@@ -645,6 +656,7 @@ public class LiquidityMonitorService {
      */
     private void handleMintLog(String pairAddress, String token0, String token1, Event event, Log logEntry) {
         try {
+            transferMonitorService.markLiquidityAdjustmentTx(logEntry.getTransactionHash(), logEntry.getBlockNumber());
             DexPriceService.PoolType poolType = event.equals(MINT_EVENT_V2)
                     ? DexPriceService.PoolType.V2
                     : DexPriceService.PoolType.V3;

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -137,13 +137,13 @@ public class LiquidityMonitorService {
     private static final Event INITIALIZE_EVENT_V4 = new Event("Initialize",
             Arrays.asList(
                     TypeReference.create(Bytes32.class, true),
-                    TypeReference.create(Address.class, true),
-                    TypeReference.create(Address.class, true),
+                    TypeReference.create(Address.class),
                     TypeReference.create(Address.class),
                     TypeReference.create(Uint24.class),
-                    TypeReference.create(Bytes32.class),
+                    TypeReference.create(Int24.class),
                     TypeReference.create(Uint160.class),
-                    TypeReference.create(Int24.class)
+                    TypeReference.create(Uint24.class),
+                    TypeReference.create(Address.class)
             ));
     /** V4 ModifyLiquidity 事件 */
     private static final Event MODIFY_LIQUIDITY_EVENT_V4 = new Event("ModifyLiquidity",
@@ -354,19 +354,19 @@ public class LiquidityMonitorService {
     private void handleV4InitializeLog(String factoryAddress, Log logEntry) {
         try {
             List<String> topics = logEntry.getTopics();
-            if (topics.size() < 4) {
+            if (topics.size() < 2) {
                 return;
             }
             String poolIdTopic = topics.get(1);
             List<Type> data = decodeEventData(logEntry.getData(), INITIALIZE_EVENT_V4);
-            if (data.size() < 5) {
+            if (data.size() < 7) {
                 return;
             }
-            String currency0 = normalizeAddress(decodeAddress(topics.get(2)));
-            String currency1 = normalizeAddress(decodeAddress(topics.get(3)));
-            String hooks = normalizeAddress(((Address) data.get(0)).getValue().toString());
-            BigInteger fee = ((Uint24) data.get(1)).getValue();
-            BigInteger sqrtPriceX96 = ((Uint160) data.get(3)).getValue();
+            String currency0 = normalizeAddress(((Address) data.get(0)).getValue());
+            String currency1 = normalizeAddress(((Address) data.get(1)).getValue());
+            BigInteger fee = ((Uint24) data.get(2)).getValue();
+            BigInteger sqrtPriceX96 = ((Uint160) data.get(4)).getValue();
+            String hooks = normalizeAddress(((Address) data.get(6)).getValue());
             if (!matchesTarget(currency0, currency1)) {
                 return;
             }

--- a/src/main/java/com/example/monitor/TransferMonitorService.java
+++ b/src/main/java/com/example/monitor/TransferMonitorService.java
@@ -24,6 +24,7 @@ import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,6 +49,10 @@ public class TransferMonitorService {
     private final TransferAggregator aggregator;
     /** 已知流动性池地址集合 */
     private final Set<String> liquidityPairs = ConcurrentHashMap.newKeySet();
+    /** 需要忽略买卖统计的流动性调整交易 */
+    private final ConcurrentHashMap<String, BigInteger> liquidityAdjustmentTxs = new ConcurrentHashMap<>();
+    /** 流动性调整交易保留的最大区块跨度 */
+    private static final BigInteger LIQUIDITY_TX_TTL_BLOCKS = BigInteger.valueOf(500L);
 
     /** Transfer 事件定义 */
     private static final Event TRANSFER_EVENT = new Event("Transfer",
@@ -92,6 +97,24 @@ public class TransferMonitorService {
     }
 
     /**
+     * 标记在统计时需要忽略的流动性调整交易
+     *
+     * @param txHash      交易哈希
+     * @param blockNumber 区块高度
+     */
+    public void markLiquidityAdjustmentTx(String txHash, BigInteger blockNumber) {
+        if (txHash == null || txHash.isEmpty()) {
+            return;
+        }
+        if (blockNumber != null) {
+            cleanupOldLiquidityTxs(blockNumber);
+            liquidityAdjustmentTxs.put(txHash.toLowerCase(Locale.ROOT), blockNumber);
+        } else {
+            liquidityAdjustmentTxs.put(txHash.toLowerCase(Locale.ROOT), null);
+        }
+    }
+
+    /**
      * 移除已知流动性池
      *
      * @param pairAddress 池子地址
@@ -128,6 +151,14 @@ public class TransferMonitorService {
             Optional<BigDecimal> priceOpt = priceService.getPriceAtBlock(blockNumber);
             BigDecimal price = priceOpt.orElse(BigDecimal.ZERO);
             BigDecimal usdValue = amount.multiply(price);
+
+            cleanupOldLiquidityTxs(blockNumber);
+
+            String txHash = logEntry.getTransactionHash();
+            if (txHash != null && liquidityAdjustmentTxs.containsKey(txHash.toLowerCase(Locale.ROOT))) {
+                log.debug("Ignoring transfer for liquidity adjustment txHash={}", txHash);
+                return;
+            }
 
             boolean fromPool = liquidityPairs.contains(fromNormalized);
             boolean toPool = liquidityPairs.contains(toNormalized);
@@ -189,5 +220,24 @@ public class TransferMonitorService {
             clean = String.format("%40s", clean).replace(' ', '0');
         }
         return "0x" + clean.substring(clean.length() - 40);
+    }
+
+    /**
+     * 清理过期的流动性调整交易记录
+     *
+     * @param currentBlock 当前处理的区块
+     */
+    private void cleanupOldLiquidityTxs(BigInteger currentBlock) {
+        if (currentBlock == null || liquidityAdjustmentTxs.isEmpty()) {
+            return;
+        }
+        BigInteger threshold = currentBlock.subtract(LIQUIDITY_TX_TTL_BLOCKS);
+        liquidityAdjustmentTxs.entrySet().removeIf(entry -> {
+            BigInteger recordedBlock = entry.getValue();
+            if (recordedBlock == null) {
+                return false;
+            }
+            return recordedBlock.compareTo(threshold) < 0;
+        });
     }
 }


### PR DESCRIPTION
## Summary
- stop registering the V4 pool identifier hash as a liquidity pair address so only real on-chain addresses are tracked for transfer stats
- track V2/V3 mint-burn and V4 modify-liquidity transactions so their transfers are ignored when computing buy/sell statistics

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central returned HTTP 403 while downloading plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68e25ab4ac8c8326bbf0081a15aba2ab