### PR TITLE
Aggregate prices across all DEX pools

### DIFF
--- a/src/main/java/com/example/monitor/BscTokenMonitor.java
+++ b/src/main/java/com/example/monitor/BscTokenMonitor.java
@@ -25,7 +25,7 @@ public class BscTokenMonitor {
      * @throws InterruptedException 中断异常
      */
     public static void main(String[] args) throws InterruptedException {
-        String tokenAddress = "0x810df4c7daf4ee06ae7c621d0680e73a505c9a06";
+        String tokenAddress = "0x302dfaf2cdbe51a18d97186a7384e87cf599877d";
         Web3j web3j = Web3j.build(new HttpService(DEFAULT_RPC_ENDPOINT));
         TokenInfoService tokenInfoService = new TokenInfoService(web3j);
         BigInteger decimals = tokenInfoService.loadDecimals(tokenAddress).orElse(BigInteger.valueOf(18));
@@ -54,3 +54,7 @@ public class BscTokenMonitor {
         latch.await();
     }
 }
+
+/**
+
+ */

--- a/src/main/java/com/example/monitor/DexConstants.java
+++ b/src/main/java/com/example/monitor/DexConstants.java
@@ -47,7 +47,8 @@ public class DexConstants {
     public static final List<BigInteger> V3_FEE_TIERS = Collections.unmodifiableList(Arrays.asList(
             BigInteger.valueOf(100),      // 0.01%
             BigInteger.valueOf(500),      // 0.05%
-            BigInteger.valueOf(2500),     // 0.25%
+            BigInteger.valueOf(2500),
+            BigInteger.valueOf(3000),// 0.25%
             BigInteger.valueOf(10000)     // 1%
     ));
 

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -152,31 +152,42 @@ public class DexPriceService {
      * @return 价格
      */
     private Optional<BigDecimal> getBestPriceForPair(String baseToken, String quoteToken, BigInteger blockNumber) {
-        List<PairMetadata> v2Pairs = findOrCreatePairs(baseToken, quoteToken);
-        Optional<BigDecimal> v2Price = getBestPriceFromPairs(v2Pairs, baseToken, blockNumber);
-        if (v2Price.isPresent()) {
-            return v2Price;
+        List<BigDecimal> prices = new ArrayList<>();
+
+        prices.addAll(collectPricesFromPairs(findOrCreatePairs(baseToken, quoteToken), baseToken, blockNumber));
+        prices.addAll(collectPricesFromPairs(findOrCreateV3Pools(baseToken, quoteToken), baseToken, blockNumber));
+        prices.addAll(collectPricesFromPairs(findOrCreateV4Pools(baseToken, quoteToken), baseToken, blockNumber));
+
+        if (prices.isEmpty()) {
+            return Optional.empty();
         }
-        List<PairMetadata> v3Pools = findOrCreateV3Pools(baseToken, quoteToken);
-        return getBestPriceFromPairs(v3Pools, baseToken, blockNumber);
+
+        BigDecimal sum = BigDecimal.ZERO;
+        for (BigDecimal price : prices) {
+            sum = sum.add(price, PRICE_MATH_CONTEXT);
+        }
+        BigDecimal average = sum.divide(BigDecimal.valueOf(prices.size()), 18, RoundingMode.HALF_UP);
+        return Optional.of(average);
     }
 
     /**
-     * 遍历池子集合获取最佳价格
+     * 遍历池子集合并收集价格
      *
      * @param pairs       池子列表
      * @param baseToken   基础代币
      * @param blockNumber 区块高度
-     * @return 价格
+     * @return 价格列表
      */
-    private Optional<BigDecimal> getBestPriceFromPairs(List<PairMetadata> pairs, String baseToken, BigInteger blockNumber) {
+    private List<BigDecimal> collectPricesFromPairs(List<PairMetadata> pairs, String baseToken, BigInteger blockNumber) {
+        if (pairs == null || pairs.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<BigDecimal> prices = new ArrayList<>();
         for (PairMetadata metadata : pairs) {
             Optional<BigDecimal> price = calculatePrice(metadata, baseToken, blockNumber);
-            if (price.isPresent()) {
-                return price.map(value -> value.setScale(18, RoundingMode.HALF_UP));
-            }
+            price.ifPresent(value -> prices.add(value.setScale(18, RoundingMode.HALF_UP)));
         }
-        return Optional.empty();
+        return prices;
     }
 
     /**
@@ -517,6 +528,21 @@ public class DexPriceService {
             }
         }
         return pools;
+    }
+
+    /**
+     * 查找或创建所有可用的 V4 池子信息
+     *
+     * <p>目前 V4 工厂缺乏稳定的 on-chain 查询接口，此处预留扩展点，
+     * 以便将 LiquidityMonitorService 等组件捕获的池子元数据注入缓存后复用。</p>
+     *
+     * @param tokenA 代币 A
+     * @param tokenB 代币 B
+     * @return 池子信息列表
+     */
+    public List<PairMetadata> findOrCreateV4Pools(String tokenA, String tokenB) {
+        // 目前返回空列表，后续可通过订阅事件或外部数据源填充 V4 池子缓存。
+        return Collections.emptyList();
     }
 
     /**

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -282,6 +282,9 @@ public class DexPriceService {
                     .divide(BigDecimal.TEN.pow(pairMetadata.token0Decimals.intValue()), 18, RoundingMode.HALF_UP);
             BigDecimal quoteReserve = reserves.getReserve1()
                     .divide(BigDecimal.TEN.pow(pairMetadata.token1Decimals.intValue()), 18, RoundingMode.HALF_UP);
+            if (!hasSufficientLiquidity(baseReserve, quoteReserve)) {
+                return Optional.empty();
+            }
             if (baseReserve.compareTo(BigDecimal.ZERO) == 0) {
                 return Optional.empty();
             }
@@ -291,12 +294,27 @@ public class DexPriceService {
                     .divide(BigDecimal.TEN.pow(pairMetadata.token1Decimals.intValue()), 18, RoundingMode.HALF_UP);
             BigDecimal quoteReserve = reserves.getReserve0()
                     .divide(BigDecimal.TEN.pow(pairMetadata.token0Decimals.intValue()), 18, RoundingMode.HALF_UP);
+            if (!hasSufficientLiquidity(baseReserve, quoteReserve)) {
+                return Optional.empty();
+            }
             if (baseReserve.compareTo(BigDecimal.ZERO) == 0) {
                 return Optional.empty();
             }
             return Optional.of(quoteReserve.divide(baseReserve, 18, RoundingMode.HALF_UP));
         }
         return Optional.empty();
+    }
+
+    /**
+     * 判断池子是否具有足够的流动性
+     *
+     * @param baseReserve  基础代币储备
+     * @param quoteReserve 报价代币储备
+     * @return 是否满足阈值
+     */
+    private boolean hasSufficientLiquidity(BigDecimal baseReserve, BigDecimal quoteReserve) {
+        BigDecimal threshold = new BigDecimal("0.001");
+        return baseReserve.compareTo(threshold) >= 0 && quoteReserve.compareTo(threshold) >= 0;
     }
 
     /**

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * DEX 价格服务
@@ -162,12 +163,42 @@ public class DexPriceService {
             return Optional.empty();
         }
 
-        BigDecimal sum = BigDecimal.ZERO;
-        for (BigDecimal price : prices) {
-            sum = sum.add(price, PRICE_MATH_CONTEXT);
+        Optional<BigDecimal> average = calculateMedianPrice(prices);
+
+        return average;
+    }
+
+    /**
+     * 计算价格中位数
+     * @param prices
+     * @return
+     */
+    private Optional<BigDecimal> calculateMedianPrice(List<BigDecimal> prices) {
+        if (prices == null || prices.isEmpty()) {
+            return Optional.empty();
         }
-        BigDecimal average = sum.divide(BigDecimal.valueOf(prices.size()), 18, RoundingMode.HALF_UP);
-        return Optional.of(average);
+
+        // 过滤掉 null 或 ≤0 的价格
+        List<BigDecimal> validPrices = prices.stream()
+                .filter(p -> p != null && p.compareTo(BigDecimal.ZERO) > 0)
+                .sorted()
+                .collect(Collectors.toList());
+
+        if (validPrices.isEmpty()) {
+            return Optional.empty();
+        }
+
+        int size = validPrices.size();
+        if (size % 2 == 1) {
+            // 奇数个，直接取中间值
+            return Optional.of(validPrices.get(size / 2));
+        } else {
+            // 偶数个，取中间两个的平均值
+            BigDecimal p1 = validPrices.get(size / 2 - 1);
+            BigDecimal p2 = validPrices.get(size / 2);
+            BigDecimal median = p1.add(p2).divide(BigDecimal.valueOf(2), 18, RoundingMode.HALF_UP);
+            return Optional.of(median);
+        }
     }
 
     /**

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -93,7 +93,7 @@ public class LiquidityMonitorService {
             Arrays.asList(
                     TypeReference.create(Address.class, true),
                     TypeReference.create(Address.class, true),
-                    TypeReference.create(Uint24.class),
+                    TypeReference.create(Uint24.class,true),
                     TypeReference.create(Int24.class),
                     TypeReference.create(Address.class)
             ));
@@ -310,13 +310,13 @@ public class LiquidityMonitorService {
                 }
                 String token0 = decodeAddress(topics.get(1));
                 String token1 = decodeAddress(topics.get(2));
+                BigInteger fee = new BigInteger(topics.get(3).substring(2),16);
                 List<Type> data = decodeEventData(logEntry.getData(), event);
-                if (data.size() < 3) {
+                if (data.size() < 2) {
                     return;
                 }
-                BigInteger fee = (BigInteger) data.get(0).getValue();
-                BigInteger tickSpacing = (BigInteger) data.get(1).getValue();
-                String poolAddress = data.get(2).getValue().toString();
+                BigInteger tickSpacing = (BigInteger) data.get(0).getValue();
+                String poolAddress = data.get(1).getValue().toString();
                 if (matchesTarget(token0, token1)) {
                     Optional<DexPriceService.PairMetadata> metadataOpt = priceService.loadPairMetadata(poolAddress, false,
                             DexPriceService.PoolType.V3, fee);

--- a/src/main/java/com/example/monitor/TradeAnalysisService.java
+++ b/src/main/java/com/example/monitor/TradeAnalysisService.java
@@ -132,6 +132,17 @@ public class TradeAnalysisService {
      * 启动监听
      */
     public void start() {
+//        BigInteger startBlock = BigInteger.valueOf(
+//                63654079
+//        );
+//        BigInteger endBlock = BigInteger.valueOf(
+//                63654081
+//        );
+//        EthFilter filter = new EthFilter(
+//                DefaultBlockParameter.valueOf(startBlock),
+//                DefaultBlockParameter.valueOf(endBlock), // 一直扫描到最新区块
+//                tokenAddress);
+
         EthFilter filter = new EthFilter(DefaultBlockParameterName.LATEST, DefaultBlockParameterName.LATEST, tokenAddress);
         filter.addSingleTopic(EventEncoder.encode(TRANSFER_EVENT));
         web3j.ethLogFlowable(filter).subscribe(this::handleTransferLog, throwable ->
@@ -155,7 +166,7 @@ public class TradeAnalysisService {
             }
 
             Optional<Transaction> transactionOpt = fetchTransaction(txHash);
-            if (transactionOpt.isEmpty()) {
+            if (!transactionOpt.isPresent()) {
                 return;
             }
             String txFrom = transactionOpt.get().getFrom();
@@ -165,7 +176,7 @@ public class TradeAnalysisService {
             String txFromNormalized = normalizeAddress(txFrom);
 
             Optional<TransactionReceipt> receiptOpt = fetchTransactionReceipt(txHash);
-            if (receiptOpt.isEmpty()) {
+            if (!receiptOpt.isPresent()) {
                 return;
             }
             TransactionReceipt receipt = receiptOpt.get();
@@ -174,7 +185,7 @@ public class TradeAnalysisService {
             }
 
             Optional<TradeDetection> detectionOpt = analyseTransactionLogs(txFromNormalized, receipt.getLogs());
-            if (detectionOpt.isEmpty()) {
+            if (!detectionOpt.isPresent()) {
                 return;
             }
             TradeDetection detection = detectionOpt.get();


### PR DESCRIPTION
## Summary
- collect prices from every discovered V2/V3/V4 pool when deriving token quotes
- compute an average price rather than returning the first successful pool value
- provide a placeholder hook for integrating V4 pool discovery data

## Testing
- mvn -q -DskipTests package *(fails: maven central 403 while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e385fd5c708326bb7222deab40125c