### PR TITLE
Filter low TVL pools when computing median price

### DIFF
--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -32,11 +32,13 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,6 +74,8 @@ public class DexPriceService {
     private final Map<String, Map<String, PairMetadata>> v3PoolCache = new ConcurrentHashMap<>();
     /** 按 token、顺序缓存的 V4 池子信息 */
     private final Map<String, Map<String, PairMetadata>> v4PoolCache = new ConcurrentHashMap<>();
+    /** 池子 TVL 缓存 */
+    private final Map<String, BigDecimal> poolTvlCache = new ConcurrentHashMap<>();
     /** 区块价格缓存 */
     private final Map<BigInteger, BigDecimal> priceCache = new ConcurrentHashMap<>();
     /** 最近一次成功获取的价格 */
@@ -79,6 +83,8 @@ public class DexPriceService {
 
     /** 价格计算精度 */
     private static final MathContext PRICE_MATH_CONTEXT = new MathContext(40, RoundingMode.HALF_UP);
+    /** 计算中位数时保留池子的最小 TVL 比例 */
+    private static final BigDecimal MIN_TVL_RATIO_FOR_MEDIAN = new BigDecimal("0.1");
 
     /**
      * 构造函数
@@ -156,11 +162,13 @@ public class DexPriceService {
      * @return 价格
      */
     private Optional<BigDecimal> getBestPriceForPair(String baseToken, String quoteToken, BigInteger blockNumber) {
-        List<BigDecimal> prices = new ArrayList<>();
+        List<PriceSample> samples = new ArrayList<>();
 
-        prices.addAll(collectPricesFromPairs(findOrCreatePairs(baseToken, quoteToken), baseToken, blockNumber));
-        prices.addAll(collectPricesFromPairs(findOrCreateV3Pools(baseToken, quoteToken), baseToken, blockNumber));
-        prices.addAll(collectPricesFromPairs(findOrCreateV4Pools(baseToken, quoteToken), baseToken, blockNumber));
+        samples.addAll(collectPriceSamplesFromPairs(findOrCreatePairs(baseToken, quoteToken), baseToken, blockNumber));
+        samples.addAll(collectPriceSamplesFromPairs(findOrCreateV3Pools(baseToken, quoteToken), baseToken, blockNumber));
+        samples.addAll(collectPriceSamplesFromPairs(findOrCreateV4Pools(baseToken, quoteToken), baseToken, blockNumber));
+
+        List<BigDecimal> prices = filterPricesByTvl(samples);
 
         if (prices.isEmpty()) {
             return Optional.empty();
@@ -212,16 +220,108 @@ public class DexPriceService {
      * @param blockNumber 区块高度
      * @return 价格列表
      */
-    private List<BigDecimal> collectPricesFromPairs(List<PairMetadata> pairs, String baseToken, BigInteger blockNumber) {
+    private List<PriceSample> collectPriceSamplesFromPairs(List<PairMetadata> pairs, String baseToken, BigInteger blockNumber) {
         if (pairs == null || pairs.isEmpty()) {
             return Collections.emptyList();
         }
-        List<BigDecimal> prices = new ArrayList<>();
+        List<PriceSample> prices = new ArrayList<>();
         for (PairMetadata metadata : pairs) {
             Optional<BigDecimal> price = calculatePrice(metadata, baseToken, blockNumber);
-            price.ifPresent(value -> prices.add(value.setScale(18, RoundingMode.HALF_UP)));
+            price.ifPresent(value -> {
+                BigDecimal normalizedPrice = value.setScale(18, RoundingMode.HALF_UP);
+                BigDecimal tvl = resolveCachedTvl(metadata);
+                prices.add(new PriceSample(normalizedPrice, tvl));
+            });
         }
         return prices;
+    }
+
+    /**
+     * 根据 TVL 过滤价格样本
+     *
+     * @param samples 价格样本
+     * @return 过滤后的价格集合
+     */
+    private List<BigDecimal> filterPricesByTvl(List<PriceSample> samples) {
+        if (samples == null || samples.isEmpty()) {
+            return Collections.emptyList();
+        }
+        BigDecimal maxTvl = samples.stream()
+                .map(sample -> sample.tvl)
+                .filter(Objects::nonNull)
+                .filter(tvl -> tvl.compareTo(BigDecimal.ZERO) > 0)
+                .max(Comparator.naturalOrder())
+                .orElse(null);
+
+        List<BigDecimal> filtered = samples.stream()
+                .filter(sample -> sample.price != null && sample.price.compareTo(BigDecimal.ZERO) > 0)
+                .filter(sample -> isTvlAcceptable(sample.tvl, maxTvl))
+                .map(sample -> sample.price)
+                .collect(Collectors.toList());
+
+        if (!filtered.isEmpty()) {
+            return filtered;
+        }
+
+        return samples.stream()
+                .filter(sample -> sample.price != null && sample.price.compareTo(BigDecimal.ZERO) > 0)
+                .map(sample -> sample.price)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 判断 TVL 是否满足过滤条件
+     *
+     * @param tvl    当前池子 TVL
+     * @param maxTvl 所有池子的最大 TVL
+     * @return 是否满足条件
+     */
+    private boolean isTvlAcceptable(BigDecimal tvl, BigDecimal maxTvl) {
+        if (tvl == null) {
+            return true;
+        }
+        if (tvl.compareTo(BigDecimal.ZERO) <= 0) {
+            return false;
+        }
+        if (maxTvl == null || maxTvl.compareTo(BigDecimal.ZERO) <= 0) {
+            return true;
+        }
+        BigDecimal threshold = maxTvl.multiply(MIN_TVL_RATIO_FOR_MEDIAN);
+        if (threshold.compareTo(BigDecimal.ZERO) <= 0) {
+            return true;
+        }
+        return tvl.compareTo(threshold) >= 0;
+    }
+
+    /**
+     * 获取缓存中的池子 TVL
+     *
+     * @param metadata 池子元数据
+     * @return TVL
+     */
+    private BigDecimal resolveCachedTvl(PairMetadata metadata) {
+        if (metadata == null || metadata.pairAddress == null) {
+            return null;
+        }
+        return poolTvlCache.get(normalize(metadata.pairAddress));
+    }
+
+    /**
+     * 更新池子的 TVL 缓存
+     *
+     * @param poolId 池子地址或 ID
+     * @param tvl    TVL 数值
+     */
+    public void updatePoolTvl(String poolId, BigDecimal tvl) {
+        if (poolId == null) {
+            return;
+        }
+        String normalized = normalize(poolId);
+        if (tvl == null || tvl.compareTo(BigDecimal.ZERO) <= 0) {
+            poolTvlCache.remove(normalized);
+        } else {
+            poolTvlCache.put(normalized, tvl);
+        }
     }
 
     /**
@@ -1168,6 +1268,19 @@ public class DexPriceService {
      */
     private String normalize(String address) {
         return address == null ? null : address.toLowerCase();
+    }
+
+    /**
+     * 价格样本
+     */
+    private static class PriceSample {
+        private final BigDecimal price;
+        private final BigDecimal tvl;
+
+        private PriceSample(BigDecimal price, BigDecimal tvl) {
+            this.price = price;
+            this.tvl = tvl;
+        }
     }
 
     /**

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -432,6 +432,8 @@ public class LiquidityMonitorService {
                 target.initialize(currency0Decimals, currency1Decimals, rawPriceOpt.orElse(null));
                 return target;
             });
+            Optional<TvlInfo> tvlOpt = calculateV4Tvl(effectiveMetadata, state);
+            priceService.updatePoolTvl(effectiveMetadata.poolId, tvlOpt.map(tvl -> tvl.amount).orElse(null));
             if (previous == null && state != null) {
                 String timestampText = formatTimestamp(resolveLogTimestamp(logEntry));
                 String swapName = resolveV4SwapName(effectiveMetadata);
@@ -444,7 +446,7 @@ public class LiquidityMonitorService {
                 String trackedPriceText = trackedPriceOpt.map(this::formatDecimal).orElse("unknown");
                 String amount0Remaining = formatAmount(state.getAmount0());
                 String amount1Remaining = formatAmount(state.getAmount1());
-                String tvlRemaining = formatTvl(calculateV4Tvl(effectiveMetadata, state));
+                String tvlRemaining = formatTvl(tvlOpt);
                 log.info("POOL_INITIALIZED_V4 swap={} name={} fee={} priceToken1PerToken0={} priceToken0PerToken1={} targetTokenPrice={} amount0Remaining={} amount1Remaining={} tvlRemaining={} time={}",
                         swapName,
                         effectiveMetadata.getDisplayName(),
@@ -543,7 +545,9 @@ public class LiquidityMonitorService {
             });
             String amount0Remaining = formatAmount(state != null ? state.getAmount0() : null);
             String amount1Remaining = formatAmount(state != null ? state.getAmount1() : null);
-            String tvlRemaining = formatTvl(calculateV4Tvl(metadata, state));
+            Optional<TvlInfo> tvlOpt = calculateV4Tvl(metadata, state);
+            priceService.updatePoolTvl(metadata.poolId, tvlOpt.map(tvl -> tvl.amount).orElse(null));
+            String tvlRemaining = formatTvl(tvlOpt);
             String timestampText = formatTimestamp(timestamp);
             String swapName = resolveV4SwapName(metadata);
             log.info("{} swap={} name={} sender={} fee={}  amount0Delta={} amount1Delta={} priceRange={}  amount0Remaining={} amount1Remaining={} tvlRemaining={}  time={}",
@@ -763,9 +767,11 @@ public class LiquidityMonitorService {
                 metadata.poolType == DexPriceService.PoolType.V2,
                 metadata.poolType,
                 metadata.fee);
+        Optional<DexPriceService.PoolSnapshot> snapshotOpt = priceService.loadPoolSnapshot(metadata);
+        Optional<TvlInfo> tvlOpt = snapshotOpt.flatMap(snapshot -> calculateTvl(metadata, snapshot));
+        priceService.updatePoolTvl(metadata.pairAddress, tvlOpt.map(tvl -> tvl.amount).orElse(null));
         String normalized = metadata.pairAddress.toLowerCase();
         if (registeredPools.add(normalized)) {
-            Optional<DexPriceService.PoolSnapshot> snapshotOpt = priceService.loadPoolSnapshot(metadata);
             String amount0Text = snapshotOpt.map(snapshot -> snapshot.token0Amount)
                     .map(this::formatDecimal)
                     .orElse("unknown");
@@ -776,7 +782,7 @@ public class LiquidityMonitorService {
                     .flatMap(snapshot -> snapshot.priceForToken(tokenAddress, metadata))
                     .map(this::formatDecimal)
                     .orElse("unknown");
-            String tvlText = formatTvl(snapshotOpt.flatMap(snapshot -> calculateTvl(metadata, snapshot)));
+            String tvlText = formatTvl(tvlOpt);
             String swapName = metadata.getSwapName();
             if (metadata.poolType == DexPriceService.PoolType.V3) {
                 Optional<DexPriceService.PriceRange> priceRangeOpt = snapshotOpt


### PR DESCRIPTION
## Summary
- filter recorded pool prices by cached TVL data before calculating the median price
- cache the latest TVL for V2, V3, and V4 pools as liquidity events arrive

## Testing
- `mvn -q -DskipTests compile` *(fails: could not download maven-resources-plugin due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e3db47f7e08326b3f043e287baf305