### PR TITLE
Use cached TVL when filtering pools

### DIFF
--- a/src/main/java/com/example/monitor/BscTokenMonitor.java
+++ b/src/main/java/com/example/monitor/BscTokenMonitor.java
@@ -25,7 +25,7 @@ public class BscTokenMonitor {
      * @throws InterruptedException 中断异常
      */
     public static void main(String[] args) throws InterruptedException {
-        String tokenAddress = "0x302dfaf2cdbe51a18d97186a7384e87cf599877d";
+        String tokenAddress = "0x76e9b54b49739837be8ad10c3687fc6b543de852";
         Web3j web3j = Web3j.build(new HttpService(DEFAULT_RPC_ENDPOINT));
         TokenInfoService tokenInfoService = new TokenInfoService(web3j);
         BigInteger decimals = tokenInfoService.loadDecimals(tokenAddress).orElse(BigInteger.valueOf(18));
@@ -42,10 +42,14 @@ public class BscTokenMonitor {
         TradeAnalysisService tradeAnalysisService = new TradeAnalysisService(web3j, tokenAddress, decimals, symbol, priceService);
         LiquidityMonitorService liquidityMonitorService = new LiquidityMonitorService(web3j, tokenAddress, priceService,
                 tradeAnalysisService, creationBlockOpt.orElse(null));
-        log.info("v2 v3开始初始化");
         liquidityMonitorService.registerInitialPairs();
+        log.info("v2 v3池子初始化完成");
         liquidityMonitorService.start();
+        log.info("流动性监控服务已启动");
         tradeAnalysisService.start();
+        log.info("交易分析服务已启动");
+        priceService.initializePriceSampler();
+        log.info("价格采样器已初始化");
 
         log.info("Monitor started. Press Ctrl+C to exit.");
         CountDownLatch latch = new CountDownLatch(1);

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -118,13 +118,12 @@ public class DexPriceService {
                 return thread;
             }
         });
-        initializePriceSampler();
     }
 
     /**
      * 初始化价格采样器，预加载常用池子并启动后台刷新任务
      */
-    private void initializePriceSampler() {
+    public void initializePriceSampler() {
         try {
             refreshInitialPools();
         } catch (Exception ex) {

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -167,6 +167,7 @@ public class DexPriceService {
         priceRefreshExecutor.scheduleAtFixedRate(() -> {
             try {
                 refreshAllKnownPools();
+                log.info("刷新价格样本完成");
             } catch (Exception ex) {
                 log.error("Failed to refresh pool prices", ex);
             }
@@ -380,7 +381,7 @@ public class DexPriceService {
 
         Optional<BigDecimal> viaWbnb = combinePrices(
                 getBestPriceForPair(tokenAddress, DexConstants.WBNB_ADDRESS, blockNumber),
-                getBestPriceForPair(DexConstants.WBNB_ADDRESS, DexConstants.USDT_ADDRESS, blockNumber)
+                getBestPriceForPairForV2V3(DexConstants.WBNB_ADDRESS, DexConstants.USDT_ADDRESS, blockNumber)
         );
         if (viaWbnb.isPresent()) {
             return Optional.of(storePrice(blockNumber, viaWbnb.get()));

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -84,6 +84,8 @@ public class DexPriceService {
     private final AtomicReference<BigDecimal> lastKnownPrice = new AtomicReference<>();
     /** 池子价格样本缓存 */
     private final Map<String, PriceSample> poolPriceCache = new ConcurrentHashMap<>();
+    /** 池子美元 TVL 缓存 */
+    private final Map<String, BigDecimal> poolUsdTvlCache = new ConcurrentHashMap<>();
     /** 价格刷新调度器 */
     private final ScheduledExecutorService priceRefreshExecutor;
 
@@ -91,6 +93,8 @@ public class DexPriceService {
     private static final MathContext PRICE_MATH_CONTEXT = new MathContext(40, RoundingMode.HALF_UP);
     /** 价格样本最大存活时间（毫秒） */
     private static final long PRICE_SAMPLE_TTL_MILLIS = 15_000L;
+    /** 池子参与价格计算所需的最小 TVL（美元） */
+    private static final BigDecimal MIN_POOL_TVL_USD = new BigDecimal("500");
 
     /**
      * 构造函数
@@ -605,6 +609,9 @@ public class DexPriceService {
                 }
             }
             if (sample != null) {
+                if (!passesUsdTvlFilter(sample)) {
+                    continue;
+                }
                 Optional<WeightedPrice> weighted = sample.toWeightedPrice(baseToken);
                 if (weighted.isPresent()) {
                     prices.add(weighted.get());
@@ -623,6 +630,60 @@ public class DexPriceService {
             }
         }
         return prices;
+    }
+
+    /**
+     * 更新池子的美元 TVL 缓存
+     */
+    public void updatePoolUsdTvl(PairMetadata metadata, BigDecimal tvlUsd) {
+        if (metadata == null) {
+            return;
+        }
+        updatePoolUsdTvl(metadata.pairAddress, tvlUsd);
+    }
+
+    /**
+     * 使用池子地址更新美元 TVL 缓存
+     */
+    public void updatePoolUsdTvl(String poolAddress, BigDecimal tvlUsd) {
+        String key = normalize(poolAddress);
+        if (key == null) {
+            return;
+        }
+        if (tvlUsd != null && tvlUsd.compareTo(BigDecimal.ZERO) > 0) {
+            poolUsdTvlCache.put(key, tvlUsd);
+        } else {
+            poolUsdTvlCache.remove(key);
+        }
+    }
+
+    /**
+     * 获取缓存的美元 TVL
+     */
+    public Optional<BigDecimal> getCachedPoolUsdTvl(String poolAddress) {
+        String key = normalize(poolAddress);
+        if (key == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(poolUsdTvlCache.get(key));
+    }
+
+    /**
+     * 检查池子的美元 TVL 是否满足阈值
+     */
+    private boolean passesUsdTvlFilter(PriceSample sample) {
+        if (sample == null || sample.metadata == null || sample.metadata.pairAddress == null) {
+            return true;
+        }
+        String key = normalize(sample.metadata.pairAddress);
+        if (key == null) {
+            return true;
+        }
+        BigDecimal cachedTvl = poolUsdTvlCache.get(key);
+        if (cachedTvl == null) {
+            return true;
+        }
+        return cachedTvl.compareTo(MIN_POOL_TVL_USD) >= 0;
     }
 
     /**

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -1649,13 +1649,14 @@ public class LiquidityMonitorService {
             return;
         }
         Optional<BigDecimal> tvlUsdOpt = calculateUsdTvlAmount(metadata, snapshot);
+        BigDecimal tvlUsd = tvlUsdOpt.orElse(null);
         if (metadata.poolType == DexPriceService.PoolType.V4) {
             String key = normalizePoolId(metadata.pairAddress);
             if (key == null) {
                 return;
             }
             if (tvlUsdOpt.isPresent()) {
-                v4PoolTvlUsdCache.put(key, tvlUsdOpt.get());
+                v4PoolTvlUsdCache.put(key, tvlUsd);
             } else {
                 v4PoolTvlUsdCache.remove(key);
             }
@@ -1665,11 +1666,12 @@ public class LiquidityMonitorService {
                 return;
             }
             if (tvlUsdOpt.isPresent()) {
-                poolTvlUsdCache.put(key, tvlUsdOpt.get());
+                poolTvlUsdCache.put(key, tvlUsd);
             } else {
                 poolTvlUsdCache.remove(key);
             }
         }
+        priceService.updatePoolUsdTvl(metadata, tvlUsd);
     }
 
     /**
@@ -1690,6 +1692,7 @@ public class LiquidityMonitorService {
                 poolTvlUsdCache.remove(key);
             }
         }
+        priceService.updatePoolUsdTvl(metadata, null);
     }
 
     /**

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -436,7 +436,6 @@ public class LiquidityMonitorService {
                 target.initialize(currency0Decimals, currency1Decimals, rawPriceOpt.orElse(null));
                 return target;
             });
-            updateV4TvlUsdCache(effectiveMetadata, state);
             if (previous == null && state != null) {
                 String timestampText = formatTimestamp(resolveLogTimestamp(logEntry));
                 String swapName = resolveV4SwapName(effectiveMetadata);
@@ -447,17 +446,14 @@ public class LiquidityMonitorService {
                         .map(this::formatDecimal)
                         .orElse("unknown");
                 String trackedPriceText = trackedPriceOpt.map(this::formatDecimal).orElse("unknown");
-                String amount0Remaining = formatAmount(state.getAmount0());
-                String amount1Remaining = formatAmount(state.getAmount1());
-                log.info("POOL_INITIALIZED_V4 swap={} name={} fee={} priceToken1PerToken0={} priceToken0PerToken1={} targetTokenPrice={} amount0Remaining={} amount1Remaining={}  time={}",
+                log.info("poolId = {} topic = POOL_INITIALIZED_V4 swap={} name={} fee={} priceToken1PerToken0={} priceToken0PerToken1={} targetTokenPrice={}  time={}",
+                        poolIdTopic,
                         swapName,
                         effectiveMetadata.getDisplayName(),
                         formatFee(fee),
                         rawPriceText,
                         inversePriceText,
                         trackedPriceText,
-                        amount0Remaining,
-                        amount1Remaining,
                         timestampText);
             }
             subscribeV4ModifyLiquidity(factoryAddress, poolIdTopic);
@@ -498,7 +494,8 @@ public class LiquidityMonitorService {
     /**
      * 处理 V4 ModifyLiquidity 日志
      *
-     * @param logEntry 日志
+     * @param logEntry 日志  想算v4的tvl 要么还得监听上 swap事件 把代币数量本地维护  如果能根据liquidity算出代币数量就好了
+     *                 如果我只拿当前活跃区间的liquidity去计算tvl  那么会不会不准确
      */
     private void handleV4ModifyLiquidityLog(Log logEntry) {
         try {
@@ -531,11 +528,6 @@ public class LiquidityMonitorService {
             BigDecimal amount1Signed = estimationOpt.map(est -> applySign(est.amount1, sign)).orElse(null);
             String amount0Text = amount0Signed != null ? formatDecimal(amount0Signed) : "unknown";
             String amount1Text = amount1Signed != null ? formatDecimal(amount1Signed) : "unknown";
-            String averagePriceText = priceRangeOpt
-                    .map(range -> range.lower.add(range.upper, PRICE_CONTEXT)
-                            .divide(BigDecimal.valueOf(2), 18, RoundingMode.HALF_UP))
-                    .map(this::formatDecimal)
-                    .orElse("unknown");
             V4PoolState state = v4PoolStates.compute(poolId, (key, existing) -> {
                 V4PoolState target = existing != null ? existing : new V4PoolState();
                 target.ensureDecimals(decimals0, decimals1);
@@ -545,12 +537,13 @@ public class LiquidityMonitorService {
                 return target;
             });
             updateV4TvlUsdCache(metadata, state);
+            String tvlRemaining = v4PoolTvlUsdCache.get(poolId).toString() +"usd";
             String amount0Remaining = formatAmount(state != null ? state.getAmount0() : null);
             String amount1Remaining = formatAmount(state != null ? state.getAmount1() : null);
-            String tvlRemaining = formatTvl(calculateV4Tvl(metadata, state));
             String timestampText = formatTimestamp(timestamp);
             String swapName = resolveV4SwapName(metadata);
-            log.info("{} swap={} name={} sender={} fee={}  amount0Delta={} amount1Delta={} priceRange={}  amount0Remaining={} amount1Remaining={} tvlRemaining={}  time={}",
+            log.info("poolId={} topic={} swap={} name={} sender={} fee={}  amount0Delta={} amount1Delta={} priceRange={}  amount0Remaining={} amount1Remaining={} tvlRemaining={}  time={}",
+                    poolId,
                     action,
                     swapName,
                     metadata.getDisplayName(),
@@ -779,11 +772,8 @@ public class LiquidityMonitorService {
             String amount1Text = snapshotOpt.map(snapshot -> snapshot.token1Amount)
                     .map(this::formatDecimal)
                     .orElse("unknown");
-            String priceText = snapshotOpt
-                    .flatMap(snapshot -> snapshot.priceForToken(tokenAddress, metadata))
-                    .map(this::formatDecimal)
-                    .orElse("unknown");
-            String tvlText = formatTvl(snapshotOpt.flatMap(snapshot -> calculateTvl(metadata, snapshot)));
+
+            String tvlText = poolTvlUsdCache.get(normalized).toString() +"USD";
             String swapName = metadata.getSwapName();
             if (metadata.poolType == DexPriceService.PoolType.V3) {
                 Optional<DexPriceService.PriceRange> priceRangeOpt = snapshotOpt
@@ -793,24 +783,22 @@ public class LiquidityMonitorService {
                                 snapshot.currentTick + snapshot.tickSpacing))
                         .orElse(Optional.empty());
                 String priceRangeText = formatPriceRange(priceRangeOpt);
-                log.info("POOL_REGISTERED pair={} swap={} name={} fee={} amount0={} amount1={} price={} priceRange={}  tvl={}",
+                log.info("POOL_REGISTERED pair={} swap={} name={} fee={} amount0={} amount1={} priceRange={}  tvl={}",
                         metadata.pairAddress,
                         swapName,
                         metadata.getDisplayName(),
                         formatFee(metadata.fee),
                         amount0Text,
                         amount1Text,
-                        priceText,
                         priceRangeText,
                         tvlText);
             } else {
-                log.info("POOL_REGISTERED pair={} swap={} name={} amount0={} amount1={} price={} tvl={}",
+                log.info("POOL_REGISTERED pair={} swap={} name={} amount0={} amount1={} tvl={}",
                         metadata.pairAddress,
                         swapName,
                         metadata.getDisplayName(),
                         amount0Text,
                         amount1Text,
-                        priceText,
                         tvlText);
             }
         }

--- a/src/main/java/com/example/monitor/TradeAnalysisService.java
+++ b/src/main/java/com/example/monitor/TradeAnalysisService.java
@@ -8,11 +8,7 @@ import org.web3j.abi.TypeReference;
 import org.web3j.abi.datatypes.Address;
 import org.web3j.abi.datatypes.Event;
 import org.web3j.abi.datatypes.Type;
-import org.web3j.abi.datatypes.generated.Int24;
-import org.web3j.abi.datatypes.generated.Int256;
-import org.web3j.abi.datatypes.generated.Uint128;
-import org.web3j.abi.datatypes.generated.Uint256;
-import org.web3j.abi.datatypes.generated.Uint160;
+import org.web3j.abi.datatypes.generated.*;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
@@ -60,7 +56,28 @@ public class TradeAnalysisService {
     private static final String TRANSFER_EVENT_SIGNATURE = EventEncoder.encode(TRANSFER_EVENT)
             .toLowerCase(Locale.ROOT);
 
-    /** V2 Swap 事件签名 */
+    /** V2 Swap 事件签名
+     *     pancakeSwap
+     *     event Swap(
+     *         address indexed sender,
+     *         uint amount0In,
+     *         uint amount1In,
+     *         uint amount0Out,
+     *         uint amount1Out,
+     *         address indexed to
+     *     );
+     *
+     * uniswap
+     *     event Swap(
+     *         address indexed sender,
+     *         uint amount0In,
+     *         uint amount1In,
+     *         uint amount0Out,
+     *         uint amount1Out,
+     *         address indexed to
+     *     );
+     *
+     * */
     private static final String SWAP_EVENT_SIGNATURE_V2 = EventEncoder.encode(new Event("Swap",
             Arrays.asList(
                     TypeReference.create(Address.class, true),
@@ -71,8 +88,47 @@ public class TradeAnalysisService {
                     TypeReference.create(Address.class, true)
             )));
 
-    /** V3 Swap 事件签名 */
-    private static final String SWAP_EVENT_SIGNATURE_V3 = EventEncoder.encode(new Event("Swap",
+    /** V3
+     *
+     * pankcakeSwap 事件签名
+     *     event Swap(
+     *         address indexed sender,
+     *         address indexed recipient,
+     *         int256 amount0,
+     *         int256 amount1,
+     *         uint160 sqrtPriceX96,
+     *         uint128 liquidity,
+     *         int24 tick,
+     *         uint128 protocolFeesToken0,
+     *         uint128 protocolFeesToken1
+     *     );
+     *
+     *     uniswapSwap 事件签名
+     *       event Swap(
+     *         address indexed sender,
+     *         address indexed recipient,
+     *         int256 amount0,
+     *         int256 amount1,
+     *         uint160 sqrtPriceX96,
+     *         uint128 liquidity,
+     *         int24 tick
+     *     );
+     *
+     * */
+
+    private static final String PANCAKE_EVENT_SIGNATURE_V3 = EventEncoder.encode(new Event("Swap",
+            Arrays.asList(
+                    TypeReference.create(Address.class, true),
+                    TypeReference.create(Address.class, true),
+                    TypeReference.create(Int256.class),
+                    TypeReference.create(Int256.class),
+                    TypeReference.create(Uint160.class),
+                    TypeReference.create(Uint128.class),
+                    TypeReference.create(Int24.class),
+                    TypeReference.create(Uint128.class),
+                    TypeReference.create(Uint128.class)
+            )));
+    private static final String UNISWAP_EVENT_SIGNATURE_V3 = EventEncoder.encode(new Event("Swap",
             Arrays.asList(
                     TypeReference.create(Address.class, true),
                     TypeReference.create(Address.class, true),
@@ -82,12 +138,69 @@ public class TradeAnalysisService {
                     TypeReference.create(Uint128.class),
                     TypeReference.create(Int24.class)
             )));
+    /**
+     * V4 Swap 事件签名
+     * pancakeSwap
+     *     event Swap(
+     *         PoolId indexed id,
+     *         address indexed sender,
+     *         int128 amount0,
+     *         int128 amount1,
+     *         uint160 sqrtPriceX96,
+     *         uint128 liquidity,
+     *         int24 tick,
+     *         uint24 fee,
+     *         uint16 protocolFee
+     *     );
+        * uniswap
+     *    event Swap(
+     *         PoolId indexed id,
+     *         address indexed sender,
+     *         int128 amount0,
+     *         int128 amount1,
+     *         uint160 sqrtPriceX96,
+     *         uint128 liquidity,
+     *         int24 tick,
+     *         uint24 fee
+     *     );
+     */
+    private static final String PANCAKESWAP_EVENT_SIGNATURE_V4 = EventEncoder.encode(new Event("Swap",
+            Arrays.asList(
+                    TypeReference.create(Bytes32.class, true),
+                    TypeReference.create(Address.class, true),
+                    TypeReference.create(Int128.class),
+                    TypeReference.create(Int128.class),
+                    TypeReference.create(Uint160.class),
+                    TypeReference.create(Uint128.class),
+                    TypeReference.create(Int24.class),
+                    TypeReference.create(Uint24.class),
+                    TypeReference.create(Uint16.class)
+            )));
+    private static final String UNISWAP_EVENT_SIGNATURE_V4 = EventEncoder.encode(new Event("Swap",
+            Arrays.asList(
+                    TypeReference.create(Bytes32.class, true),
+                    TypeReference.create(Address.class, true),
+                    TypeReference.create(Int128.class),
+                    TypeReference.create(Int128.class),
+                    TypeReference.create(Uint160.class),
+                    TypeReference.create(Uint128.class),
+                    TypeReference.create(Int24.class),
+                    TypeReference.create(Int24.class)
+            )));
+
 
     /** 支持的 Swap 事件签名集合 */
     private static final Set<String> SUPPORTED_SWAP_SIGNATURES = new HashSet<>(Arrays.asList(
             SWAP_EVENT_SIGNATURE_V2.toLowerCase(Locale.ROOT),
-            SWAP_EVENT_SIGNATURE_V3.toLowerCase(Locale.ROOT)
+            UNISWAP_EVENT_SIGNATURE_V3.toLowerCase(Locale.ROOT),
+            PANCAKE_EVENT_SIGNATURE_V3.toLowerCase(Locale.ROOT),
+            UNISWAP_EVENT_SIGNATURE_V4.toLowerCase(Locale.ROOT),
+            PANCAKESWAP_EVENT_SIGNATURE_V4.toLowerCase(Locale.ROOT)
     ));
+
+    public static void main(String[] args) {
+        SUPPORTED_SWAP_SIGNATURES.forEach(item -> System.out.println(item));
+    }
 
     /** Web3j 客户端 */
     private final Web3j web3j;
@@ -200,7 +313,7 @@ public class TradeAnalysisService {
                 return;
             }
 
-            Optional<TradeDetection> detectionOpt = analyseTransactionLogs(txFromNormalized, receipt.getLogs());
+            Optional<TradeDetection> detectionOpt = analyseTransactionLogs(txFromNormalized, receipt.getLogs(),txHash);
             if (!detectionOpt.isPresent()) {
                 return;
             }
@@ -223,7 +336,7 @@ public class TradeAnalysisService {
 
             log.info("TRADE address={} action={} amount={} {} price=${} value=${} totalBuyAmount={} totalSellAmount={} " +
                             "totalBuyValue=${} totalSellValue=${} netAmount={} netValue=${} avgBuyPrice=${} avgSellPrice=${} trades={} " +
-                            "grossIn={} grossOut={} block={} time={} txHash={}",
+                            " block={} time={} txHash={}",
                     txFrom,
                     detection.direction.getDisplay(),
                     detection.tradeAmount.setScale(6, RoundingMode.HALF_UP),
@@ -239,8 +352,6 @@ public class TradeAnalysisService {
                     summary.avgBuyPrice.setScale(8, RoundingMode.HALF_UP),
                     summary.avgSellPrice.setScale(8, RoundingMode.HALF_UP),
                     summary.tradeCount,
-                    detection.totalIn.setScale(6, RoundingMode.HALF_UP),
-                    detection.totalOut.setScale(6, RoundingMode.HALF_UP),
                     blockNumber,
                     Instant.ofEpochMilli(timestamp).atZone(TARGET_ZONE).format(TIME_FORMATTER),
                     txHash);
@@ -256,7 +367,7 @@ public class TradeAnalysisService {
      * @param logs             交易所有日志
      * @return 交易识别结果
      */
-    private Optional<TradeDetection> analyseTransactionLogs(String txFromNormalized, List<Log> logs) {
+    private Optional<TradeDetection> analyseTransactionLogs(String txFromNormalized, List<Log> logs,String txHash) {
         if (logs == null || logs.isEmpty()) {
             return Optional.empty();
         }
@@ -289,6 +400,7 @@ public class TradeAnalysisService {
             if (decoded.isEmpty()) {
                 continue;
             }
+
             BigInteger value = (BigInteger) decoded.get(0).getValue();
             if (txFromNormalized.equals(normalizeAddress(from))) {
                 totalOutRaw = totalOutRaw.add(value);
@@ -305,6 +417,7 @@ public class TradeAnalysisService {
         BigDecimal totalIn = toDecimalAmount(totalInRaw);
         BigDecimal totalOut = toDecimalAmount(totalOutRaw);
         if (totalIn.signum() == 0 && totalOut.signum() == 0) {
+            log.info("Zero trade amounts detected in tx {}",txHash);
             return Optional.empty();
         }
 
@@ -319,6 +432,7 @@ public class TradeAnalysisService {
         } else {
             BigDecimal net = totalIn.subtract(totalOut);
             if (net.signum() == 0) {
+                log.info("net in tx {}",txHash);
                 return Optional.empty();
             }
             direction = net.signum() > 0 ? TradeDirection.BUY : TradeDirection.SELL;


### PR DESCRIPTION
## Summary
- store USD TVL values pushed from LiquidityMonitorService in DexPriceService
- filter pool price samples using the cached USD TVL instead of estimating on the fly
- keep the DexPriceService TVL cache in sync when LiquidityMonitorService clears or refreshes values

## Testing
- `mvn -q -DskipTests compile` *(fails: unable to download maven-resources-plugin due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e4be9f58c08326a72ce1a1eae09d75