### PR TITLE
Fix V4 liquidity amount scaling

### DIFF
--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -83,6 +83,8 @@ public class LiquidityMonitorService {
     private static final ZoneId TARGET_TIME_ZONE = ZoneId.of("Asia/Shanghai");
     /** 日志时间格式 */
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+    /** Q96 常量 */
+    private static final BigDecimal Q96 = new BigDecimal(BigInteger.ONE.shiftLeft(96));
 
     /** V2 PairCreated 事件 */
     private static final Event PAIR_CREATED_EVENT = new Event("PairCreated",
@@ -1154,15 +1156,19 @@ public class LiquidityMonitorService {
             BigDecimal numerator = liquidity.multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
             BigDecimal denominator = sqrtUpper.multiply(sqrtLower, PRICE_CONTEXT);
             amount0Raw = numerator.divide(denominator, 18, RoundingMode.HALF_UP);
+            amount0Raw = amount0Raw.divide(Q96, 18, RoundingMode.HALF_UP);
             amount1Raw = BigDecimal.ZERO;
         } else if (sqrtCurrent.compareTo(sqrtUpper) >= 0) {
             amount0Raw = BigDecimal.ZERO;
             amount1Raw = liquidity.multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
+            amount1Raw = amount1Raw.divide(Q96, 18, RoundingMode.HALF_UP);
         } else {
             BigDecimal numerator0 = liquidity.multiply(sqrtUpper.subtract(sqrtCurrent, PRICE_CONTEXT), PRICE_CONTEXT);
             BigDecimal denominator0 = sqrtCurrent.multiply(sqrtUpper, PRICE_CONTEXT);
             amount0Raw = numerator0.divide(denominator0, 18, RoundingMode.HALF_UP);
+            amount0Raw = amount0Raw.divide(Q96, 18, RoundingMode.HALF_UP);
             amount1Raw = liquidity.multiply(sqrtCurrent.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
+            amount1Raw = amount1Raw.divide(Q96, 18, RoundingMode.HALF_UP);
         }
         BigDecimal normalized0 = normalizeTokenAmount(amount0Raw, decimals0);
         BigDecimal normalized1 = normalizeTokenAmount(amount1Raw, decimals1);

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -9,7 +9,6 @@ import org.web3j.abi.datatypes.Address;
 import org.web3j.abi.datatypes.Event;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.generated.Bytes32;
-import org.web3j.abi.datatypes.generated.Int128;
 import org.web3j.abi.datatypes.generated.Int24;
 import org.web3j.abi.datatypes.generated.Int256;
 import org.web3j.abi.datatypes.generated.Uint128;
@@ -173,8 +172,6 @@ public class LiquidityMonitorService {
                     TypeReference.create(Int24.class),
                     TypeReference.create(Int24.class),
                     TypeReference.create(Int256.class),
-                    TypeReference.create(Int128.class),
-                    TypeReference.create(Int128.class),
                     TypeReference.create(Bytes32.class)
             ));
 
@@ -515,7 +512,7 @@ public class LiquidityMonitorService {
                 return;
             }
             List<Type> data = decodeEventData(logEntry.getData(), MODIFY_LIQUIDITY_EVENT_V4);
-            if (data.size() < 6) {
+            if (data.size() < 4) {
                 return;
             }
             String sender = normalizeAddress(decodeAddress(topics.get(2)));
@@ -531,17 +528,10 @@ public class LiquidityMonitorService {
             String priceRangeText = formatPriceRange(priceRangeOpt);
             V4PoolState existingState = v4PoolStates.get(poolId);
             BigDecimal currentPrice = existingState != null ? existingState.resolvePrice() : null;
-            BigInteger rawAmount0Delta = ((Int128) data.get(3)).getValue();
-            BigInteger rawAmount1Delta = ((Int128) data.get(4)).getValue();
-            Bytes32 saltBytes = (Bytes32) data.get(5);
-            BigDecimal amount0Delta = normalizeTokenAmount(new BigDecimal(rawAmount0Delta), decimals0);
-            BigDecimal amount1Delta = normalizeTokenAmount(new BigDecimal(rawAmount1Delta), decimals1);
-            boolean missingAmount0 = amount0Delta == null;
-            boolean missingAmount1 = amount1Delta == null;
-            boolean bothZero = !missingAmount0 && !missingAmount1
-                    && amount0Delta.compareTo(BigDecimal.ZERO) == 0
-                    && amount1Delta.compareTo(BigDecimal.ZERO) == 0;
-            if (liquidityDelta.signum() != 0 && (missingAmount0 || missingAmount1 || bothZero)) {
+            Bytes32 saltBytes = (Bytes32) data.get(3);
+            BigDecimal amount0Delta = null;
+            BigDecimal amount1Delta = null;
+            if (liquidityDelta.signum() != 0) {
                 Optional<LiquidityEstimation> estimationOpt = estimateV4LiquidityDelta(
                         liquidityDelta,
                         tickLower,
@@ -551,12 +541,8 @@ public class LiquidityMonitorService {
                         currentPrice);
                 if (estimationOpt.isPresent()) {
                     LiquidityEstimation estimation = estimationOpt.get();
-                    if (missingAmount0 || bothZero) {
-                        amount0Delta = applySign(estimation.amount0, sign);
-                    }
-                    if (missingAmount1 || bothZero) {
-                        amount1Delta = applySign(estimation.amount1, sign);
-                    }
+                    amount0Delta = applySign(estimation.amount0, sign);
+                    amount1Delta = applySign(estimation.amount1, sign);
                 }
             }
             String amount0Text = amount0Delta != null ? formatDecimal(amount0Delta) : "unknown";

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -83,8 +83,6 @@ public class LiquidityMonitorService {
     private static final ZoneId TARGET_TIME_ZONE = ZoneId.of("Asia/Shanghai");
     /** 日志时间格式 */
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-    /** Q96 常量 */
-    private static final BigDecimal Q96 = new BigDecimal(BigInteger.ONE.shiftLeft(96));
 
     /** V2 PairCreated 事件 */
     private static final Event PAIR_CREATED_EVENT = new Event("PairCreated",
@@ -525,7 +523,15 @@ public class LiquidityMonitorService {
             BigInteger decimals1 = priceService.resolveTokenDecimals(metadata.currency1);
             Optional<DexPriceService.PriceRange> priceRangeOpt = calculateV4PriceRange(metadata, decimals0, decimals1, tickLower, tickUpper);
             String priceRangeText = formatPriceRange(priceRangeOpt);
-            Optional<LiquidityEstimation> estimationOpt = estimateV4LiquidityDelta(liquidityDelta, tickLower, tickUpper, decimals0, decimals1);
+            V4PoolState existingState = v4PoolStates.get(poolId);
+            BigDecimal currentPrice = existingState != null ? existingState.resolvePrice() : null;
+            Optional<LiquidityEstimation> estimationOpt = estimateV4LiquidityDelta(
+                    liquidityDelta,
+                    tickLower,
+                    tickUpper,
+                    decimals0,
+                    decimals1,
+                    currentPrice);
             BigDecimal amount0Signed = estimationOpt.map(est -> applySign(est.amount0, sign)).orElse(null);
             BigDecimal amount1Signed = estimationOpt.map(est -> applySign(est.amount1, sign)).orElse(null);
             String amount0Text = amount0Signed != null ? formatDecimal(amount0Signed) : "unknown";
@@ -1137,7 +1143,8 @@ public class LiquidityMonitorService {
                                                                    int tickLower,
                                                                    int tickUpper,
                                                                    BigInteger decimals0,
-                                                                   BigInteger decimals1) {
+                                                                   BigInteger decimals1,
+                                                                   BigDecimal currentPriceToken1PerToken0) {
         if (liquidityDelta == null || liquidityDelta.equals(BigInteger.ZERO)) {
             return Optional.empty();
         }
@@ -1148,7 +1155,7 @@ public class LiquidityMonitorService {
                 || sqrtUpper.compareTo(BigDecimal.ZERO) <= 0) {
             return Optional.empty();
         }
-        BigDecimal sqrtCurrent = sqrtRatioAtTick((tickLower + tickUpper) / 2);
+        BigDecimal sqrtCurrent = resolveSqrtCurrent(tickLower, tickUpper, currentPriceToken1PerToken0);
         BigDecimal liquidity = new BigDecimal(liquidityDelta.abs());
         BigDecimal amount0Raw;
         BigDecimal amount1Raw;
@@ -1156,23 +1163,44 @@ public class LiquidityMonitorService {
             BigDecimal numerator = liquidity.multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
             BigDecimal denominator = sqrtUpper.multiply(sqrtLower, PRICE_CONTEXT);
             amount0Raw = numerator.divide(denominator, 18, RoundingMode.HALF_UP);
-            amount0Raw = amount0Raw.divide(Q96, 18, RoundingMode.HALF_UP);
             amount1Raw = BigDecimal.ZERO;
         } else if (sqrtCurrent.compareTo(sqrtUpper) >= 0) {
             amount0Raw = BigDecimal.ZERO;
             amount1Raw = liquidity.multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
-            amount1Raw = amount1Raw.divide(Q96, 18, RoundingMode.HALF_UP);
         } else {
             BigDecimal numerator0 = liquidity.multiply(sqrtUpper.subtract(sqrtCurrent, PRICE_CONTEXT), PRICE_CONTEXT);
             BigDecimal denominator0 = sqrtCurrent.multiply(sqrtUpper, PRICE_CONTEXT);
             amount0Raw = numerator0.divide(denominator0, 18, RoundingMode.HALF_UP);
-            amount0Raw = amount0Raw.divide(Q96, 18, RoundingMode.HALF_UP);
             amount1Raw = liquidity.multiply(sqrtCurrent.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
-            amount1Raw = amount1Raw.divide(Q96, 18, RoundingMode.HALF_UP);
         }
         BigDecimal normalized0 = normalizeTokenAmount(amount0Raw, decimals0);
         BigDecimal normalized1 = normalizeTokenAmount(amount1Raw, decimals1);
         return Optional.of(new LiquidityEstimation(normalized0, normalized1));
+    }
+
+    /**
+     * 解析当前价格对应的 sqrt 值
+     */
+    private BigDecimal resolveSqrtCurrent(int tickLower, int tickUpper, BigDecimal currentPriceToken1PerToken0) {
+        BigDecimal sqrtFromPrice = sqrtDecimal(currentPriceToken1PerToken0);
+        if (sqrtFromPrice != null) {
+            return sqrtFromPrice;
+        }
+        return sqrtRatioAtTick((tickLower + tickUpper) / 2);
+    }
+
+    /**
+     * 对价格开平方根
+     */
+    private BigDecimal sqrtDecimal(BigDecimal price) {
+        if (price == null || price.compareTo(BigDecimal.ZERO) <= 0) {
+            return null;
+        }
+        double sqrt = Math.sqrt(price.doubleValue());
+        if (Double.isNaN(sqrt) || Double.isInfinite(sqrt)) {
+            return null;
+        }
+        return new BigDecimal(Double.toString(sqrt), PRICE_CONTEXT);
     }
 
     /**

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -9,6 +9,7 @@ import org.web3j.abi.datatypes.Address;
 import org.web3j.abi.datatypes.Event;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.generated.Bytes32;
+import org.web3j.abi.datatypes.generated.Int128;
 import org.web3j.abi.datatypes.generated.Int24;
 import org.web3j.abi.datatypes.generated.Int256;
 import org.web3j.abi.datatypes.generated.Uint128;
@@ -23,6 +24,7 @@ import org.web3j.protocol.core.methods.request.EthFilter;
 import org.web3j.protocol.core.methods.response.Log;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.utils.Numeric;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -171,6 +173,8 @@ public class LiquidityMonitorService {
                     TypeReference.create(Int24.class),
                     TypeReference.create(Int24.class),
                     TypeReference.create(Int256.class),
+                    TypeReference.create(Int128.class),
+                    TypeReference.create(Int128.class),
                     TypeReference.create(Bytes32.class)
             ));
 
@@ -511,7 +515,7 @@ public class LiquidityMonitorService {
                 return;
             }
             List<Type> data = decodeEventData(logEntry.getData(), MODIFY_LIQUIDITY_EVENT_V4);
-            if (data.size() < 4) {
+            if (data.size() < 6) {
                 return;
             }
             String sender = normalizeAddress(decodeAddress(topics.get(2)));
@@ -527,22 +531,41 @@ public class LiquidityMonitorService {
             String priceRangeText = formatPriceRange(priceRangeOpt);
             V4PoolState existingState = v4PoolStates.get(poolId);
             BigDecimal currentPrice = existingState != null ? existingState.resolvePrice() : null;
-            Optional<LiquidityEstimation> estimationOpt = estimateV4LiquidityDelta(
-                    liquidityDelta,
-                    tickLower,
-                    tickUpper,
-                    decimals0,
-                    decimals1,
-                    currentPrice);
-            BigDecimal amount0Signed = estimationOpt.map(est -> applySign(est.amount0, sign)).orElse(null);
-            BigDecimal amount1Signed = estimationOpt.map(est -> applySign(est.amount1, sign)).orElse(null);
-            String amount0Text = amount0Signed != null ? formatDecimal(amount0Signed) : "unknown";
-            String amount1Text = amount1Signed != null ? formatDecimal(amount1Signed) : "unknown";
+            BigInteger rawAmount0Delta = ((Int128) data.get(3)).getValue();
+            BigInteger rawAmount1Delta = ((Int128) data.get(4)).getValue();
+            Bytes32 saltBytes = (Bytes32) data.get(5);
+            BigDecimal amount0Delta = normalizeTokenAmount(new BigDecimal(rawAmount0Delta), decimals0);
+            BigDecimal amount1Delta = normalizeTokenAmount(new BigDecimal(rawAmount1Delta), decimals1);
+            boolean missingAmount0 = amount0Delta == null;
+            boolean missingAmount1 = amount1Delta == null;
+            boolean bothZero = !missingAmount0 && !missingAmount1
+                    && amount0Delta.compareTo(BigDecimal.ZERO) == 0
+                    && amount1Delta.compareTo(BigDecimal.ZERO) == 0;
+            if (liquidityDelta.signum() != 0 && (missingAmount0 || missingAmount1 || bothZero)) {
+                Optional<LiquidityEstimation> estimationOpt = estimateV4LiquidityDelta(
+                        liquidityDelta,
+                        tickLower,
+                        tickUpper,
+                        decimals0,
+                        decimals1,
+                        currentPrice);
+                if (estimationOpt.isPresent()) {
+                    LiquidityEstimation estimation = estimationOpt.get();
+                    if (missingAmount0 || bothZero) {
+                        amount0Delta = applySign(estimation.amount0, sign);
+                    }
+                    if (missingAmount1 || bothZero) {
+                        amount1Delta = applySign(estimation.amount1, sign);
+                    }
+                }
+            }
+            String amount0Text = amount0Delta != null ? formatDecimal(amount0Delta) : "unknown";
+            String amount1Text = amount1Delta != null ? formatDecimal(amount1Delta) : "unknown";
             V4PoolState state = v4PoolStates.compute(poolId, (key, existing) -> {
                 V4PoolState target = existing != null ? existing : new V4PoolState();
                 target.ensureDecimals(decimals0, decimals1);
-                if (amount0Signed != null || amount1Signed != null) {
-                    target.applyDelta(amount0Signed, amount1Signed);
+                if (amount0Delta != null || amount1Delta != null) {
+                    target.applyDelta(amount0Delta, amount1Delta);
                 }
                 return target;
             });
@@ -552,19 +575,22 @@ public class LiquidityMonitorService {
             String amount1Remaining = formatAmount(state != null ? state.getAmount1() : null);
             String timestampText = formatTimestamp(timestamp);
             String swapName = resolveV4SwapName(metadata);
-            log.info("poolId={} topic={} swap={} name={} sender={} fee={}  amount0Delta={} amount1Delta={} priceRange={}  amount0Remaining={} amount1Remaining={} tvlRemaining={}  time={}",
+            String salt = saltBytes != null ? Numeric.toHexString(saltBytes.getValue()) : "";
+            log.info("poolId={} topic={} swap={} name={} sender={} fee={} liquidityDelta={} amount0Delta={} amount1Delta={} priceRange={}  amount0Remaining={} amount1Remaining={} tvlRemaining={} salt={} time={}",
                     poolId,
                     action,
                     swapName,
                     metadata.getDisplayName(),
                     sender,
                     formatFee(metadata.fee),
+                    liquidityDelta,
                     amount0Text,
                     amount1Text,
                     priceRangeText,
                     amount0Remaining,
                     amount1Remaining,
                     tvlRemaining,
+                    salt,
                     timestampText);
         } catch (Exception ex) {
             log.error("Failed to handle V4 modify liquidity log", ex);
@@ -1760,10 +1786,17 @@ public class LiquidityMonitorService {
      * 格式化十进制数
      */
     private String formatDecimal(BigDecimal value) {
+        if (value == null) {
+            return "unknown";
+        }
         BigDecimal scaled = value.setScale(6, RoundingMode.HALF_UP);
+        if (scaled.compareTo(BigDecimal.ZERO) == 0 && value.compareTo(BigDecimal.ZERO) != 0) {
+            int dynamicScale = Math.min(18, Math.max(6, value.scale() + 6));
+            scaled = value.setScale(dynamicScale, RoundingMode.HALF_UP);
+        }
         BigDecimal normalized = scaled.stripTrailingZeros();
         if (normalized.compareTo(BigDecimal.ZERO) == 0) {
-            return "0";
+            return value.compareTo(BigDecimal.ZERO) == 0 ? "0" : scaled.toPlainString();
         }
         return normalized.toPlainString();
     }

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -503,18 +503,15 @@ public class LiquidityMonitorService {
     private void handleV4ModifyLiquidityLog(Log logEntry) {
         try {
             List<String> topics = logEntry.getTopics();
-            if (topics.size() < 3) {
-                return;
-            }
+            if (topics.size() < 3) return;
+
             String poolId = normalizePoolId(topics.get(1));
             V4PoolMetadata metadata = v4Pools.get(poolId);
-            if (metadata == null) {
-                return;
-            }
+            if (metadata == null) return;
+
             List<Type> data = decodeEventData(logEntry.getData(), MODIFY_LIQUIDITY_EVENT_V4);
-            if (data.size() < 4) {
-                return;
-            }
+            if (data.size() < 4) return;
+
             String sender = normalizeAddress(decodeAddress(topics.get(2)));
             int tickLower = ((Int24) data.get(0)).getValue().intValue();
             int tickUpper = ((Int24) data.get(1)).getValue().intValue();
@@ -522,15 +519,22 @@ public class LiquidityMonitorService {
             int sign = liquidityDelta.signum();
             String action = sign > 0 ? "POOL_ADDED_V4" : (sign < 0 ? "POOL_REMOVED_V4" : "POOL_UPDATED_V4");
             Instant timestamp = resolveLogTimestamp(logEntry);
+
+            // ✅ 获取代币精度
             BigInteger decimals0 = priceService.resolveTokenDecimals(metadata.currency0);
             BigInteger decimals1 = priceService.resolveTokenDecimals(metadata.currency1);
-            Optional<DexPriceService.PriceRange> priceRangeOpt = calculateV4PriceRange(metadata, decimals0, decimals1, tickLower, tickUpper);
-            String priceRangeText = formatPriceRange(priceRangeOpt);
+
             V4PoolState existingState = v4PoolStates.get(poolId);
             BigDecimal currentPrice = existingState != null ? existingState.resolvePrice() : null;
+
+            // ✅ 计算 tick 区间价格范围
+            Optional<DexPriceService.PriceRange> priceRangeOpt = calculateV4PriceRange(metadata, decimals0, decimals1, tickLower, tickUpper);
+            String priceRangeText = formatPriceRange(priceRangeOpt);
+
             Bytes32 saltBytes = (Bytes32) data.get(3);
-            BigDecimal amount0Delta = null;
-            BigDecimal amount1Delta = null;
+            BigDecimal amount0Delta = BigDecimal.ZERO;
+            BigDecimal amount1Delta = BigDecimal.ZERO;
+
             if (liquidityDelta.signum() != 0) {
                 Optional<LiquidityEstimation> estimationOpt = estimateV4LiquidityDelta(
                         liquidityDelta,
@@ -538,31 +542,41 @@ public class LiquidityMonitorService {
                         tickUpper,
                         decimals0,
                         decimals1,
-                        currentPrice);
+                        currentPrice
+                );
+
                 if (estimationOpt.isPresent()) {
                     LiquidityEstimation estimation = estimationOpt.get();
-                    amount0Delta = applySign(estimation.amount0, sign);
-                    amount1Delta = applySign(estimation.amount1, sign);
+                    amount0Delta = estimation.amount0.multiply(BigDecimal.valueOf(sign));
+                    amount1Delta = estimation.amount1.multiply(BigDecimal.valueOf(sign));
                 }
             }
-            String amount0Text = amount0Delta != null ? formatDecimal(amount0Delta) : "unknown";
-            String amount1Text = amount1Delta != null ? formatDecimal(amount1Delta) : "unknown";
+
+            // ✅ 更新池状态（非累计）
             V4PoolState state = v4PoolStates.compute(poolId, (key, existing) -> {
                 V4PoolState target = existing != null ? existing : new V4PoolState();
                 target.ensureDecimals(decimals0, decimals1);
-                if (amount0Delta != null || amount1Delta != null) {
+                if (amount0Delta.signum() != 0 || amount1Delta.signum() != 0) {
                     target.applyDelta(amount0Delta, amount1Delta);
                 }
                 return target;
             });
+
+            // ✅ 更新 TVL
             updateV4TvlUsdCache(metadata, state);
-            String tvlRemaining = v4PoolTvlUsdCache.get(poolId).toString() +"usd";
+
+            String amount0Text = formatDecimal(amount0Delta);
+            String amount1Text = formatDecimal(amount1Delta);
             String amount0Remaining = formatAmount(state != null ? state.getAmount0() : null);
             String amount1Remaining = formatAmount(state != null ? state.getAmount1() : null);
+            String tvlRemaining = v4PoolTvlUsdCache.get(poolId) + " USD";
             String timestampText = formatTimestamp(timestamp);
             String swapName = resolveV4SwapName(metadata);
             String salt = saltBytes != null ? Numeric.toHexString(saltBytes.getValue()) : "";
-            log.info("poolId={} topic={} swap={} name={} sender={} fee={} liquidityDelta={} amount0Delta={} amount1Delta={} priceRange={}  amount0Remaining={} amount1Remaining={} tvlRemaining={} salt={} time={}",
+
+            log.info("POOL_MODIFY_V4 poolId={} action={} swap={} name={} sender={} fee={} " +
+                            "liquidityDelta={} amount0Delta={} amount1Delta={} priceRange={} " +
+                            "amount0Remaining={} amount1Remaining={} tvlRemaining={} salt={} time={}",
                     poolId,
                     action,
                     swapName,
@@ -579,7 +593,7 @@ public class LiquidityMonitorService {
                     salt,
                     timestampText);
         } catch (Exception ex) {
-            log.error("Failed to handle V4 modify liquidity log", ex);
+            log.error("Failed to handle V4 ModifyLiquidity log", ex);
         }
     }
 
@@ -1153,15 +1167,18 @@ public class LiquidityMonitorService {
      * @param decimals1      货币 1 精度
      * @return 估算结果
      */
-    private Optional<LiquidityEstimation> estimateV4LiquidityDelta(BigInteger liquidityDelta,
-                                                                   int tickLower,
-                                                                   int tickUpper,
-                                                                   BigInteger decimals0,
-                                                                   BigInteger decimals1,
-                                                                   BigDecimal currentPriceToken1PerToken0) {
+    private Optional<LiquidityEstimation> estimateV4LiquidityDelta(
+            BigInteger liquidityDelta,
+            int tickLower,
+            int tickUpper,
+            BigInteger decimals0,
+            BigInteger decimals1,
+            BigDecimal currentPriceToken1PerToken0) {
+
         if (liquidityDelta == null || liquidityDelta.equals(BigInteger.ZERO)) {
             return Optional.empty();
         }
+
         BigDecimal sqrtLower = sqrtRatioAtTick(tickLower);
         BigDecimal sqrtUpper = sqrtRatioAtTick(tickUpper);
         if (sqrtLower == null || sqrtUpper == null
@@ -1169,31 +1186,39 @@ public class LiquidityMonitorService {
                 || sqrtUpper.compareTo(BigDecimal.ZERO) <= 0) {
             return Optional.empty();
         }
-        BigDecimal sqrtCurrent = resolveSqrtCurrent(tickLower, tickUpper, currentPriceToken1PerToken0);
-        BigDecimal liquidity = new BigDecimal(liquidityDelta.abs());
+
+        // ✅ 当前价格平方根
+        BigDecimal sqrtCurrent = sqrtPrice(currentPriceToken1PerToken0);
+        BigDecimal L = new BigDecimal(liquidityDelta.abs());
         BigDecimal amount0Raw;
         BigDecimal amount1Raw;
+
+        // ✅ 判断区间关系
         if (sqrtCurrent.compareTo(sqrtLower) <= 0) {
-            BigDecimal numerator = liquidity.multiply(Q96, PRICE_CONTEXT)
-                    .multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
-            BigDecimal denominator = sqrtUpper.multiply(sqrtLower, PRICE_CONTEXT);
-            amount0Raw = safeDivide(numerator, denominator);
+            // 当前价格低于区间 → 全部为 token0
+            amount0Raw = L.multiply(sqrtUpper.subtract(sqrtLower))
+                    .divide(sqrtUpper.multiply(sqrtLower), PRICE_CONTEXT);
             amount1Raw = BigDecimal.ZERO;
         } else if (sqrtCurrent.compareTo(sqrtUpper) >= 0) {
+            // 当前价格高于区间 → 全部为 token1
             amount0Raw = BigDecimal.ZERO;
-            amount1Raw = liquidity.multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT)
-                    .divide(Q96, 18, RoundingMode.HALF_UP);
+            amount1Raw = L.multiply(sqrtUpper.subtract(sqrtLower));
         } else {
-            BigDecimal numerator0 = liquidity.multiply(Q96, PRICE_CONTEXT)
-                    .multiply(sqrtUpper.subtract(sqrtCurrent, PRICE_CONTEXT), PRICE_CONTEXT);
-            BigDecimal denominator0 = sqrtCurrent.multiply(sqrtUpper, PRICE_CONTEXT);
-            amount0Raw = safeDivide(numerator0, denominator0);
-            amount1Raw = liquidity.multiply(sqrtCurrent.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT)
-                    .divide(Q96, 18, RoundingMode.HALF_UP);
+            // 当前价格在区间内
+            amount0Raw = L.multiply(sqrtUpper.subtract(sqrtCurrent))
+                    .divide(sqrtCurrent.multiply(sqrtUpper), PRICE_CONTEXT);
+            amount1Raw = L.multiply(sqrtCurrent.subtract(sqrtLower));
         }
-        BigDecimal normalized0 = normalizeTokenAmount(amount0Raw, decimals0);
-        BigDecimal normalized1 = normalizeTokenAmount(amount1Raw, decimals1);
-        return Optional.of(new LiquidityEstimation(normalized0, normalized1));
+
+        // ✅ 除以代币精度
+        BigDecimal amount0 = amount0Raw.divide(BigDecimal.TEN.pow(decimals0.intValue()), PRICE_CONTEXT);
+        BigDecimal amount1 = amount1Raw.divide(BigDecimal.TEN.pow(decimals1.intValue()), PRICE_CONTEXT);
+
+        return Optional.of(new LiquidityEstimation(amount0, amount1));
+    }
+
+    private BigDecimal sqrtPrice(BigDecimal priceToken1PerToken0) {
+        return BigDecimal.valueOf(Math.sqrt(priceToken1PerToken0.doubleValue()));
     }
 
     /**

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -79,6 +79,8 @@ public class LiquidityMonitorService {
     private static final BigInteger MAX_LOG_BLOCK_RANGE = BigInteger.valueOf(50_000L);
     /** 价格计算精度 */
     private static final MathContext PRICE_CONTEXT = new MathContext(40, RoundingMode.HALF_UP);
+    /** Q96 固定点常量 */
+    private static final BigDecimal Q96 = new BigDecimal(BigInteger.ONE.shiftLeft(96));
     /** 日志时间时区 */
     private static final ZoneId TARGET_TIME_ZONE = ZoneId.of("Asia/Shanghai");
     /** 日志时间格式 */
@@ -1160,18 +1162,22 @@ public class LiquidityMonitorService {
         BigDecimal amount0Raw;
         BigDecimal amount1Raw;
         if (sqrtCurrent.compareTo(sqrtLower) <= 0) {
-            BigDecimal numerator = liquidity.multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
+            BigDecimal numerator = liquidity.multiply(Q96, PRICE_CONTEXT)
+                    .multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
             BigDecimal denominator = sqrtUpper.multiply(sqrtLower, PRICE_CONTEXT);
-            amount0Raw = numerator.divide(denominator, 18, RoundingMode.HALF_UP);
+            amount0Raw = safeDivide(numerator, denominator);
             amount1Raw = BigDecimal.ZERO;
         } else if (sqrtCurrent.compareTo(sqrtUpper) >= 0) {
             amount0Raw = BigDecimal.ZERO;
-            amount1Raw = liquidity.multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
+            amount1Raw = liquidity.multiply(sqrtUpper.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT)
+                    .divide(Q96, 18, RoundingMode.HALF_UP);
         } else {
-            BigDecimal numerator0 = liquidity.multiply(sqrtUpper.subtract(sqrtCurrent, PRICE_CONTEXT), PRICE_CONTEXT);
+            BigDecimal numerator0 = liquidity.multiply(Q96, PRICE_CONTEXT)
+                    .multiply(sqrtUpper.subtract(sqrtCurrent, PRICE_CONTEXT), PRICE_CONTEXT);
             BigDecimal denominator0 = sqrtCurrent.multiply(sqrtUpper, PRICE_CONTEXT);
-            amount0Raw = numerator0.divide(denominator0, 18, RoundingMode.HALF_UP);
-            amount1Raw = liquidity.multiply(sqrtCurrent.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT);
+            amount0Raw = safeDivide(numerator0, denominator0);
+            amount1Raw = liquidity.multiply(sqrtCurrent.subtract(sqrtLower, PRICE_CONTEXT), PRICE_CONTEXT)
+                    .divide(Q96, 18, RoundingMode.HALF_UP);
         }
         BigDecimal normalized0 = normalizeTokenAmount(amount0Raw, decimals0);
         BigDecimal normalized1 = normalizeTokenAmount(amount1Raw, decimals1);
@@ -1184,7 +1190,7 @@ public class LiquidityMonitorService {
     private BigDecimal resolveSqrtCurrent(int tickLower, int tickUpper, BigDecimal currentPriceToken1PerToken0) {
         BigDecimal sqrtFromPrice = sqrtDecimal(currentPriceToken1PerToken0);
         if (sqrtFromPrice != null) {
-            return sqrtFromPrice;
+            return sqrtFromPrice.multiply(Q96, PRICE_CONTEXT);
         }
         return sqrtRatioAtTick((tickLower + tickUpper) / 2);
     }
@@ -1326,7 +1332,17 @@ public class LiquidityMonitorService {
     private BigDecimal sqrtRatioAtTick(int tick) {
         double exponent = tick / 2.0d;
         double value = Math.pow(1.0001d, exponent);
-        return new BigDecimal(Double.toString(value), PRICE_CONTEXT);
+        return new BigDecimal(Double.toString(value), PRICE_CONTEXT).multiply(Q96, PRICE_CONTEXT);
+    }
+
+    private BigDecimal safeDivide(BigDecimal numerator, BigDecimal denominator) {
+        if (numerator == null || denominator == null) {
+            return BigDecimal.ZERO;
+        }
+        if (denominator.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return numerator.divide(denominator, 18, RoundingMode.HALF_UP);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add the missing Q96 constant to normalize V4 liquidity conversions
- divide estimated token deltas by Q96 so amount0/amount1 match DEX calculations

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download maven-resources-plugin because of 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e55faa47a88326ae1d922cbcd01c83