### PR TITLE
Add USDC liquidity monitoring support

### DIFF
--- a/src/main/java/com/example/monitor/DexConstants.java
+++ b/src/main/java/com/example/monitor/DexConstants.java
@@ -32,6 +32,13 @@ public class DexConstants {
     public static final String WBNB_ADDRESS = "0xBB4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c";
     /** BUSD 代币地址 */
     public static final String USDT_ADDRESS = "0x55d398326f99059ff775485246999027b3197955";
+    /** USDC 代币地址 */
+    public static final String USDC_ADDRESS = "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d";
+    /** 稳定币地址列表 */
+    public static final List<String> STABLE_TOKEN_ADDRESSES = Collections.unmodifiableList(Arrays.asList(
+            USDT_ADDRESS,
+            USDC_ADDRESS
+    ));
 
     /** PancakeSwap V2 工厂列表 */
     public static final List<String> V2_FACTORIES = Collections.unmodifiableList(Arrays.asList(

--- a/src/main/java/com/example/monitor/DexPriceService.java
+++ b/src/main/java/com/example/monitor/DexPriceService.java
@@ -137,15 +137,19 @@ public class DexPriceService {
      */
     private void refreshInitialPools() {
         List<PairMetadata> initialPools = new ArrayList<>();
-        initialPools.addAll(findPairsForCache(tokenAddress, DexConstants.USDT_ADDRESS));
+        DexConstants.STABLE_TOKEN_ADDRESSES.forEach(stable -> {
+            initialPools.addAll(findPairsForCache(tokenAddress, stable));
+            initialPools.addAll(findV3PoolsForCache(tokenAddress, stable));
+            initialPools.addAll(findOrCreateV4Pools(tokenAddress, stable));
+        });
         initialPools.addAll(findPairsForCache(tokenAddress, DexConstants.WBNB_ADDRESS));
-        initialPools.addAll(findV3PoolsForCache(tokenAddress, DexConstants.USDT_ADDRESS));
         initialPools.addAll(findV3PoolsForCache(tokenAddress, DexConstants.WBNB_ADDRESS));
-        initialPools.addAll(findOrCreateV4Pools(tokenAddress, DexConstants.USDT_ADDRESS));
         initialPools.addAll(findOrCreateV4Pools(tokenAddress, DexConstants.WBNB_ADDRESS));
-        initialPools.addAll(findPairsForCache(DexConstants.WBNB_ADDRESS, DexConstants.USDT_ADDRESS));
-        initialPools.addAll(findV3PoolsForCache(DexConstants.WBNB_ADDRESS, DexConstants.USDT_ADDRESS));
-        initialPools.addAll(findOrCreateV4Pools(DexConstants.WBNB_ADDRESS, DexConstants.USDT_ADDRESS));
+        DexConstants.STABLE_TOKEN_ADDRESSES.forEach(stable -> {
+            initialPools.addAll(findPairsForCache(DexConstants.WBNB_ADDRESS, stable));
+            initialPools.addAll(findV3PoolsForCache(DexConstants.WBNB_ADDRESS, stable));
+            initialPools.addAll(findOrCreateV4Pools(DexConstants.WBNB_ADDRESS, stable));
+        });
 
         Set<String> seen = new HashSet<>();
         for (PairMetadata metadata : initialPools) {
@@ -374,17 +378,22 @@ public class DexPriceService {
             return Optional.of(cached);
         }
 
-        Optional<BigDecimal> directBusd = getBestPriceForPair(tokenAddress, DexConstants.USDT_ADDRESS, blockNumber);
-        if (directBusd.isPresent()) {
-            return Optional.of(storePrice(blockNumber, directBusd.get()));
+        for (String stable : DexConstants.STABLE_TOKEN_ADDRESSES) {
+            Optional<BigDecimal> direct = getBestPriceForPair(tokenAddress, stable, blockNumber);
+            if (direct.isPresent()) {
+                return Optional.of(storePrice(blockNumber, direct.get()));
+            }
         }
 
-        Optional<BigDecimal> viaWbnb = combinePrices(
-                getBestPriceForPair(tokenAddress, DexConstants.WBNB_ADDRESS, blockNumber),
-                getBestPriceForPairForV2V3(DexConstants.WBNB_ADDRESS, DexConstants.USDT_ADDRESS, blockNumber)
-        );
-        if (viaWbnb.isPresent()) {
-            return Optional.of(storePrice(blockNumber, viaWbnb.get()));
+        Optional<BigDecimal> tokenWbnb = getBestPriceForPair(tokenAddress, DexConstants.WBNB_ADDRESS, blockNumber);
+        for (String stable : DexConstants.STABLE_TOKEN_ADDRESSES) {
+            Optional<BigDecimal> viaWbnb = combinePrices(
+                    tokenWbnb,
+                    getBestPriceForPairForV2V3(DexConstants.WBNB_ADDRESS, stable, blockNumber)
+            );
+            if (viaWbnb.isPresent()) {
+                return Optional.of(storePrice(blockNumber, viaWbnb.get()));
+            }
         }
 
         BigDecimal fallback = lastKnownPrice.get();
@@ -405,21 +414,27 @@ public class DexPriceService {
         if (tokenAddress == null) {
             return Optional.empty();
         }
-        if (tokenAddress.equalsIgnoreCase(DexConstants.USDT_ADDRESS)) {
+        if (tokenAddress.equalsIgnoreCase(DexConstants.USDT_ADDRESS) ||
+                tokenAddress.equalsIgnoreCase(DexConstants.USDC_ADDRESS)) {
             return Optional.of(BigDecimal.ONE);
         }
 
-        Optional<BigDecimal> direct = getBestPriceForPair(tokenAddress, DexConstants.USDT_ADDRESS, null);
-        if (direct.isPresent()) {
-            return Optional.of(direct.get().setScale(18, RoundingMode.HALF_UP));
+        for (String stable : DexConstants.STABLE_TOKEN_ADDRESSES) {
+            Optional<BigDecimal> direct = getBestPriceForPair(tokenAddress, stable, null);
+            if (direct.isPresent()) {
+                return Optional.of(direct.get().setScale(18, RoundingMode.HALF_UP));
+            }
         }
 
-        Optional<BigDecimal> viaWbnb = combinePrices(
-                getBestPriceForPair(tokenAddress, DexConstants.WBNB_ADDRESS, null),
-                getBestPriceForPairForV2V3(DexConstants.WBNB_ADDRESS, DexConstants.USDT_ADDRESS, null)
-        );
-        if (viaWbnb.isPresent()) {
-            return Optional.of(viaWbnb.get().setScale(18, RoundingMode.HALF_UP));
+        Optional<BigDecimal> tokenWbnb = getBestPriceForPair(tokenAddress, DexConstants.WBNB_ADDRESS, null);
+        for (String stable : DexConstants.STABLE_TOKEN_ADDRESSES) {
+            Optional<BigDecimal> viaWbnb = combinePrices(
+                    tokenWbnb,
+                    getBestPriceForPairForV2V3(DexConstants.WBNB_ADDRESS, stable, null)
+            );
+            if (viaWbnb.isPresent()) {
+                return Optional.of(viaWbnb.get().setScale(18, RoundingMode.HALF_UP));
+            }
         }
 
         return Optional.empty();
@@ -434,21 +449,27 @@ public class DexPriceService {
         if (tokenAddress == null) {
             return Optional.empty();
         }
-        if (tokenAddress.equalsIgnoreCase(DexConstants.USDT_ADDRESS)) {
+        if (tokenAddress.equalsIgnoreCase(DexConstants.USDT_ADDRESS) ||
+                tokenAddress.equalsIgnoreCase(DexConstants.USDC_ADDRESS)) {
             return Optional.of(BigDecimal.ONE);
         }
 
-        Optional<BigDecimal> direct = getBestPriceForPairForV2V3(tokenAddress, DexConstants.USDT_ADDRESS, null);
-        if (direct.isPresent()) {
-            return Optional.of(direct.get().setScale(18, RoundingMode.HALF_UP));
+        for (String stable : DexConstants.STABLE_TOKEN_ADDRESSES) {
+            Optional<BigDecimal> direct = getBestPriceForPairForV2V3(tokenAddress, stable, null);
+            if (direct.isPresent()) {
+                return Optional.of(direct.get().setScale(18, RoundingMode.HALF_UP));
+            }
         }
 
-        Optional<BigDecimal> viaWbnb = combinePrices(
-                getBestPriceForPairForV2V3(tokenAddress, DexConstants.WBNB_ADDRESS, null),
-                getBestPriceForPairForV2V3(DexConstants.WBNB_ADDRESS, DexConstants.USDT_ADDRESS, null)
-        );
-        if (viaWbnb.isPresent()) {
-            return Optional.of(viaWbnb.get().setScale(18, RoundingMode.HALF_UP));
+        Optional<BigDecimal> tokenWbnb = getBestPriceForPairForV2V3(tokenAddress, DexConstants.WBNB_ADDRESS, null);
+        for (String stable : DexConstants.STABLE_TOKEN_ADDRESSES) {
+            Optional<BigDecimal> viaWbnb = combinePrices(
+                    tokenWbnb,
+                    getBestPriceForPairForV2V3(DexConstants.WBNB_ADDRESS, stable, null)
+            );
+            if (viaWbnb.isPresent()) {
+                return Optional.of(viaWbnb.get().setScale(18, RoundingMode.HALF_UP));
+            }
         }
 
         return Optional.empty();

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -210,24 +210,26 @@ public class LiquidityMonitorService {
      * 手动注册初始池子
      */
     public void registerInitialPairs() {
-        priceService.findOrCreatePairs(tokenAddress, DexConstants.USDT_ADDRESS)
-                .forEach(pair -> {
-                    registerPool(pair);
-                    subscribeMint(pair, MINT_EVENT_V2);
-                    subscribeBurn(pair, BURN_EVENT_V2);
-                });
+        DexConstants.STABLE_TOKEN_ADDRESSES.forEach(stable ->
+                priceService.findOrCreatePairs(tokenAddress, stable)
+                        .forEach(pair -> {
+                            registerPool(pair);
+                            subscribeMint(pair, MINT_EVENT_V2);
+                            subscribeBurn(pair, BURN_EVENT_V2);
+                        }));
         priceService.findOrCreatePairs(tokenAddress, DexConstants.WBNB_ADDRESS)
                 .forEach(pair -> {
                     registerPool(pair);
                     subscribeMint(pair, MINT_EVENT_V2);
                     subscribeBurn(pair, BURN_EVENT_V2);
                 });
-        priceService.findOrCreateV3Pools(tokenAddress, DexConstants.USDT_ADDRESS)
-                .forEach(pool -> {
-                    registerPool(pool);
-                    subscribeMint(pool, MINT_EVENT_V3);
-                    subscribeBurn(pool, BURN_EVENT_V3);
-                });
+        DexConstants.STABLE_TOKEN_ADDRESSES.forEach(stable ->
+                priceService.findOrCreateV3Pools(tokenAddress, stable)
+                        .forEach(pool -> {
+                            registerPool(pool);
+                            subscribeMint(pool, MINT_EVENT_V3);
+                            subscribeBurn(pool, BURN_EVENT_V3);
+                        }));
         priceService.findOrCreateV3Pools(tokenAddress, DexConstants.WBNB_ADDRESS)
                 .forEach(pool -> {
                     registerPool(pool);
@@ -1792,10 +1794,10 @@ public class LiquidityMonitorService {
 
         BigDecimal tvlAmount;
         String symbol;
-        if (metadata.token1.equalsIgnoreCase(DexConstants.USDT_ADDRESS)) {
+        if (isStableToken(metadata.token1)) {
             symbol = resolveSymbol(metadata.token1Symbol, metadata.token1);
             tvlAmount = amount1.add(amount0.multiply(ratio, PRICE_CONTEXT));
-        } else if (metadata.token0.equalsIgnoreCase(DexConstants.USDT_ADDRESS)) {
+        } else if (isStableToken(metadata.token0)) {
             symbol = resolveSymbol(metadata.token0Symbol, metadata.token0);
             tvlAmount = amount0.add(amount1.divide(ratio, 18, RoundingMode.HALF_UP));
         } else if (metadata.token0.equalsIgnoreCase(tokenAddress)) {
@@ -1814,6 +1816,17 @@ public class LiquidityMonitorService {
         }
 
         return Optional.of(new TvlInfo(tvlAmount.setScale(18, RoundingMode.HALF_UP), symbol));
+    }
+
+    /**
+     * 判断是否为稳定币
+     */
+    private boolean isStableToken(String address) {
+        if (address == null) {
+            return false;
+        }
+        return DexConstants.STABLE_TOKEN_ADDRESSES.stream()
+                .anyMatch(stable -> stable.equalsIgnoreCase(address));
     }
 
     /**


### PR DESCRIPTION
## Summary
- add the USDC contract constant and track stable token addresses centrally
- preload and price pools that include USDC across V2, V3, and V4 in the DEX price service
- register USDC pools for liquidity monitoring and treat stable tokens uniformly when calculating TVL

## Testing
- mvn -q -DskipTests package *(fails: unable to download maven-resources-plugin due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e616991d388326b3a98f00a4782fa4