### PR TITLE
Split Web3j HTTP queries from WebSocket subscriptions

### DIFF
--- a/src/main/java/com/example/monitor/BscTokenMonitor.java
+++ b/src/main/java/com/example/monitor/BscTokenMonitor.java
@@ -4,8 +4,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.http.HttpService;
+import org.web3j.protocol.websocket.WebSocketService;
 
 import java.math.BigInteger;
+import java.net.ConnectException;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 
@@ -16,7 +18,8 @@ public class BscTokenMonitor {
     /** 日志记录器 */
     private static final Logger log = LoggerFactory.getLogger(BscTokenMonitor.class);
     /** 默认 BSC RPC 节点（免费） */
-    private static final String DEFAULT_RPC_ENDPOINT = "https://bsc-mainnet.nodereal.io/v1/9613675572f24988819d24233504b290";
+    private static final String DEFAULT_HTTP_ENDPOINT = "https://bsc-mainnet.nodereal.io/v1/9613675572f24988819d24233504b290";
+    private static final String DEFAULT_WS_ENDPOINT = "wss://bsc-mainnet.nodereal.io/ws/v1/9613675572f24988819d24233504b290";
 
     /**
      * 程序入口函数
@@ -26,8 +29,17 @@ public class BscTokenMonitor {
      */
     public static void main(String[] args) throws InterruptedException {
         String tokenAddress = "0xf3d5b4c34ed623478cc5141861776e6cf7ae3a1e";
-        Web3j web3j = Web3j.build(new HttpService(DEFAULT_RPC_ENDPOINT));
-        TokenInfoService tokenInfoService = new TokenInfoService(web3j);
+        Web3j httpWeb3j = Web3j.build(new HttpService(DEFAULT_HTTP_ENDPOINT));
+
+        WebSocketService webSocketService = new WebSocketService(DEFAULT_WS_ENDPOINT, true);
+        try {
+            webSocketService.connect();
+        } catch (ConnectException e) {
+            throw new IllegalStateException("Unable to connect to WebSocket endpoint", e);
+        }
+        Web3j wsWeb3j = Web3j.build(webSocketService);
+
+        TokenInfoService tokenInfoService = new TokenInfoService(httpWeb3j);
         BigInteger decimals = tokenInfoService.loadDecimals(tokenAddress).orElse(BigInteger.valueOf(18));
         String symbol = tokenInfoService.loadSymbol(tokenAddress).orElse("TOKEN");
         Optional<BigInteger> creationBlockOpt = tokenInfoService.findCreationBlock(tokenAddress);
@@ -39,10 +51,10 @@ public class BscTokenMonitor {
         log.info("Starting monitor for token={} decimals={}", symbol, decimals);
 
         DatabaseLogService databaseLogService = new DatabaseLogService("jdbc:h2:./monitor-logs");
-        DexPriceService priceService = new DexPriceService(web3j, tokenAddress, decimals, symbol);
-        TradeAnalysisService tradeAnalysisService = new TradeAnalysisService(web3j, tokenAddress, decimals, symbol,
+        DexPriceService priceService = new DexPriceService(httpWeb3j, tokenAddress, decimals, symbol);
+        TradeAnalysisService tradeAnalysisService = new TradeAnalysisService(httpWeb3j, wsWeb3j, tokenAddress, decimals, symbol,
                 priceService, databaseLogService);
-        LiquidityMonitorService liquidityMonitorService = new LiquidityMonitorService(web3j, tokenAddress, priceService,
+        LiquidityMonitorService liquidityMonitorService = new LiquidityMonitorService(httpWeb3j, wsWeb3j, tokenAddress, priceService,
                 tradeAnalysisService, creationBlockOpt.orElse(null), databaseLogService);
         liquidityMonitorService.registerInitialPairs();
         log.info("v2 v3池子初始化完成");

--- a/src/main/java/com/example/monitor/LiquidityMonitorService.java
+++ b/src/main/java/com/example/monitor/LiquidityMonitorService.java
@@ -49,8 +49,10 @@ import java.util.function.Consumer;
 public class LiquidityMonitorService {
     /** 日志记录器 */
     private static final Logger log = LoggerFactory.getLogger(LiquidityMonitorService.class);
-    /** Web3j 客户端 */
+    /** Web3j HTTP 客户端 */
     private final Web3j web3j;
+    /** WebSocket 订阅使用的 Web3j 客户端 */
+    private final Web3j subscriptionWeb3j;
     /** 目标代币地址 */
     private final String tokenAddress;
     /** 价格服务 */
@@ -190,10 +192,11 @@ public class LiquidityMonitorService {
     /**
      * 构造函数
      */
-    public LiquidityMonitorService(Web3j web3j, String tokenAddress, DexPriceService priceService,
+    public LiquidityMonitorService(Web3j httpWeb3j, Web3j subscriptionWeb3j, String tokenAddress, DexPriceService priceService,
                                    TradeAnalysisService tradeAnalysisService, BigInteger tokenCreationBlock,
                                    DatabaseLogService databaseLogService) {
-        this.web3j = web3j;
+        this.web3j = httpWeb3j;
+        this.subscriptionWeb3j = subscriptionWeb3j;
         this.tokenAddress = tokenAddress.toLowerCase();
         this.priceService = priceService;
         this.tradeAnalysisService = tradeAnalysisService;
@@ -251,7 +254,7 @@ public class LiquidityMonitorService {
     private void subscribeFactory(String factoryAddress, Event event) {
         EthFilter filter = new EthFilter(DefaultBlockParameterName.LATEST, DefaultBlockParameterName.LATEST, factoryAddress);
         filter.addSingleTopic(EventEncoder.encode(event));
-        web3j.ethLogFlowable(filter).subscribe(logEntry -> handleFactoryLog(event, logEntry), throwable ->
+        subscriptionWeb3j.ethLogFlowable(filter).subscribe(logEntry -> handleFactoryLog(event, logEntry), throwable ->
                 log.error("Error processing factory event", throwable));
     }
 
@@ -271,7 +274,7 @@ public class LiquidityMonitorService {
         );
         EthFilter initFilter = new EthFilter(subscriptionStart, DefaultBlockParameterName.LATEST, factoryAddress);
         initFilter.addSingleTopic(EventEncoder.encode(initEvent));
-        web3j.ethLogFlowable(initFilter).subscribe(logEntry -> handleV4InitializeLog(factoryAddress, logEntry), throwable ->
+        subscriptionWeb3j.ethLogFlowable(initFilter).subscribe(logEntry -> handleV4InitializeLog(factoryAddress, logEntry), throwable ->
                 log.error("Error processing V4 initialize event", throwable));
     }
 
@@ -548,7 +551,7 @@ public class LiquidityMonitorService {
         EthFilter modifyFilter = new EthFilter(subscriptionStart, DefaultBlockParameterName.LATEST, factoryAddress);
         modifyFilter.addSingleTopic(EventEncoder.encode(MODIFY_LIQUIDITY_EVENT_V4));
         modifyFilter.addOptionalTopics(normalizedPoolId);
-        web3j.ethLogFlowable(modifyFilter).subscribe(logEntry -> handleV4ModifyLiquidityLog(logEntry), throwable ->
+        subscriptionWeb3j.ethLogFlowable(modifyFilter).subscribe(logEntry -> handleV4ModifyLiquidityLog(logEntry), throwable ->
                 log.error("Error processing V4 modify liquidity event", throwable));
     }
 
@@ -827,7 +830,7 @@ public class LiquidityMonitorService {
         }
         EthFilter filter = new EthFilter(DefaultBlockParameterName.LATEST, DefaultBlockParameterName.LATEST, pairAddress);
         filter.addSingleTopic(eventTopic);
-        web3j.ethLogFlowable(filter).subscribe(logEntry -> handleBurnLog(pairAddress, token0, token1, event, logEntry), throwable ->
+        subscriptionWeb3j.ethLogFlowable(filter).subscribe(logEntry -> handleBurnLog(pairAddress, token0, token1, event, logEntry), throwable ->
                 log.error("Error processing burn event", throwable));
     }
 
@@ -851,7 +854,7 @@ public class LiquidityMonitorService {
         }
         EthFilter filter = new EthFilter(DefaultBlockParameterName.LATEST, DefaultBlockParameterName.LATEST, pairAddress);
         filter.addSingleTopic(eventTopic);
-        web3j.ethLogFlowable(filter).subscribe(logEntry -> handleMintLog(pairAddress, token0, token1, event, logEntry), throwable ->
+        subscriptionWeb3j.ethLogFlowable(filter).subscribe(logEntry -> handleMintLog(pairAddress, token0, token1, event, logEntry), throwable ->
                 log.error("Error processing mint event", throwable));
     }
 

--- a/src/main/java/com/example/monitor/TradeAnalysisService.java
+++ b/src/main/java/com/example/monitor/TradeAnalysisService.java
@@ -214,8 +214,10 @@ public class TradeAnalysisService {
         SUPPORTED_SWAP_SIGNATURES.forEach(item -> System.out.println(item));
     }
 
-    /** Web3j 客户端 */
+    /** Web3j HTTP 客户端 */
     private final Web3j web3j;
+    /** WebSocket 订阅用的 Web3j 客户端 */
+    private final Web3j subscriptionWeb3j;
     /** 监控的代币地址 */
     private final String tokenAddress;
     /** 代币符号 */
@@ -237,9 +239,10 @@ public class TradeAnalysisService {
     /**
      * 构造函数
      */
-    public TradeAnalysisService(Web3j web3j, String tokenAddress, BigInteger tokenDecimals, String tokenSymbol,
+    public TradeAnalysisService(Web3j httpWeb3j, Web3j subscriptionWeb3j, String tokenAddress, BigInteger tokenDecimals, String tokenSymbol,
                                 DexPriceService priceService, DatabaseLogService databaseLogService) {
-        this.web3j = web3j;
+        this.web3j = httpWeb3j;
+        this.subscriptionWeb3j = subscriptionWeb3j;
         this.tokenAddress = tokenAddress.toLowerCase(Locale.ROOT);
         this.tokenSymbol = tokenSymbol;
         this.priceService = priceService;
@@ -279,7 +282,7 @@ public class TradeAnalysisService {
 
         EthFilter filter = new EthFilter(DefaultBlockParameterName.LATEST, DefaultBlockParameterName.LATEST, tokenAddress);
         filter.addSingleTopic(EventEncoder.encode(TRANSFER_EVENT));
-        web3j.ethLogFlowable(filter).subscribe(this::handleTransferLog, throwable ->
+        subscriptionWeb3j.ethLogFlowable(filter).subscribe(this::handleTransferLog, throwable ->
                 log.error("Error processing trade analysis transfer log", throwable));
     }
 


### PR DESCRIPTION
## Summary
- build dedicated HTTP and WebSocket Web3j clients in the monitor bootstrap
- route subscription-based flowables through the WebSocket client while keeping historical queries on the HTTP client
- update dependent services to accept both clients so log subscriptions and data lookups use the appropriate transport

## Testing
- mvn -q -DskipTests compile *(fails: 403 Forbidden fetching maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e63a8f8fb48326a210536bacca9055